### PR TITLE
Add except field on ask rules and relax watch-secrets severity

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ClaudeWatch",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "PreToolUse hook that enforce command safety rules via 'claude-watches'",
   "author": {
     "name": "chris-peterson"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ This is a Claude Code plugin that enforces Bash command safety via a `PreToolUse
 
 **Hook protocol:** Claude Code passes tool invocations as JSON on stdin. The hook outputs `{"decision":"block",...}`, `{"decision":"ask",...}`, or nothing (allow). Exit code must always be 0.
 
-**YAML format:** Each rules file has top-level `name`, optional `filter` (regex pre-check to skip irrelevant commands), and a `rules` map with `block`/`ask` lists. Each rule has `name`, `pattern`, `reason`, and `ref` fields. `watchdog.py` ships a minimal pure-Python parser — no external dependencies. See the [schema reference](https://chris-peterson.github.io/ClaudeWatch/#/schema) for details.
+**YAML format:** Each rules file has top-level `name`, optional `filter` (regex pre-check to skip irrelevant commands), and a `rules` map with `block`/`ask` lists. Each rule has `name`, `pattern`, `reason`, and `ref` fields. Ask rules also support an optional `except` field — a regex that skips the rule for known-safe patterns (ignored on block rules). `watchdog.py` ships a minimal pure-Python parser — no external dependencies. See the [schema reference](https://chris-peterson.github.io/ClaudeWatch/#/schema) for details.
 
 **Rule patterns** are Python regexes matched with `re.search()` (matches anywhere in the command string). This is the core safety advantage over Claude Code's built-in deny rules, which use `startsWith()` and miss compound commands like `git add . && git commit`.
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -18,6 +18,7 @@ rules:
   ask:                    # rules that require user confirmation
     - name: <string>
       pattern: '<regex>'
+      except: '<regex>'   # optional — skip this rule if except matches
       reason: <string>
       ref: <url>
 ```
@@ -59,12 +60,12 @@ Contains two lists: `block` and `ask`. Both are optional (you can have a rule se
 **Evaluation order:**
 
 1. All `block` rules are checked first, in order. First match wins — the command is rejected.
-2. If no block rule matches, all `ask` rules are checked in order. First match wins — the user is prompted.
+2. If no block rule matches, all `ask` rules are checked in order. For each matching ask rule, if `except` is set and matches the command, that rule is skipped. First non-excepted match wins — the user is prompted.
 3. If nothing matches, the command is allowed silently.
 
 ## Rule fields
 
-Each rule in a `block` or `ask` list has four fields:
+Each rule in a `block` or `ask` list has these fields:
 
 ### `name` (required)
 
@@ -107,6 +108,20 @@ URL to relevant documentation. Shown at the end of the block/ask message. Can be
 ```yaml
 ref: https://git-scm.com/docs/git-push#Documentation/git-push.txt--f
 ```
+
+### `except` (optional, ask rules only)
+
+A Python regex that exempts matching commands from this rule. If `except` matches the command, the rule is skipped even though `pattern` matched. This reduces prompt noise for known-safe patterns without weakening block rules.
+
+```yaml
+- name: rm -rf
+  pattern: 'rm\s+-[a-zA-Z]*r[a-zA-Z]*f'
+  except: 'rm\s+(-[a-zA-Z]+\s+)*(~/\.cache/|/tmp/|/var/tmp/)'
+  reason: recursively deletes files and directories
+  ref: https://man7.org/linux/man-pages/man1/rm.1.html
+```
+
+Using `except` on a `block` rule emits a warning and is ignored — block rules always fire.
 
 ## Hook wiring
 
@@ -175,6 +190,7 @@ rules:
   ask:
     - name: docker run
       pattern: 'docker\s+run(\s|$)'
+      except: 'docker\s+run\s+--rm\b'
       reason: starts a new container
       ref: https://docs.docker.com/reference/cli/docker/container/run/
 ```

--- a/rules/watch-files.yml
+++ b/rules/watch-files.yml
@@ -31,11 +31,13 @@ rules:
   ask:
     - name: rm -rf
       pattern: 'rm\s+-[a-zA-Z]*r[a-zA-Z]*f|rm\s+-[a-zA-Z]*f[a-zA-Z]*r'
+      except: 'rm\s+(-[a-zA-Z]+\s+)*(~/\.cache/|/tmp/|/var/tmp/)'
       reason: recursively deletes files and directories
       ref: https://man7.org/linux/man-pages/man1/rm.1.html
 
     - name: rm -r
       pattern: 'rm\s+-[a-zA-Z]*r'
+      except: 'rm\s+(-[a-zA-Z]+\s+)*(~/\.cache/|/tmp/|/var/tmp/)'
       reason: recursively deletes directories
       ref: https://man7.org/linux/man-pages/man1/rm.1.html
 

--- a/rules/watch-secrets.yml
+++ b/rules/watch-secrets.yml
@@ -1,4 +1,5 @@
 name: watch-secrets
+filter: '\b(cat|echo|printf|export|env|printenv|less|more|head|tail)\b'
 
 rules:
   block:
@@ -12,9 +13,15 @@ rules:
       reason: exposes cloud provider credentials
       ref: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
 
-    - name: expose secrets
-      pattern: '(?i)(echo|printf|cat|less|more|head|tail)\s+.*(secret|token|password|credential|api.?key|private.?key)'
-      reason: may expose secret values
+    - name: echo secret env var
+      pattern: '(?i)(echo|printf)\s+.*\$\{?\w*(SECRET|TOKEN|PASSWORD|API.?KEY|PRIVATE.?KEY)'
+      reason: prints a secret-named environment variable, exposing its value
+      ref: https://cwe.mitre.org/data/definitions/532.html
+
+  ask:
+    - name: read files with secret-like names
+      pattern: '(?i)(cat|less|more|head|tail)\s+(?=\S*[/~.])\S*(secret|token|password|credential|api.?key|private.?key)'
+      reason: filename suggests it may contain secrets
       ref: https://cwe.mitre.org/data/definitions/532.html
 
     - name: export secrets inline
@@ -32,7 +39,6 @@ rules:
       reason: may expose private keys or certificates
       ref: https://man.openbsd.org/openssl.1
 
-  ask:
     - name: env / printenv
       pattern: '\b(env|printenv)\b'
       reason: dumps all environment variables which may include secrets

--- a/scripts/watchdog.py
+++ b/scripts/watchdog.py
@@ -89,6 +89,12 @@ def parse_rules_yml(path):
             elif indent == 6 and stripped.startswith("ref:") and current_item is not None:
                 current_item["ref"] = _unquote(stripped[4:].strip())
 
+            elif indent == 6 and stripped.startswith("except:") and current_item is not None:
+                if current_section == "block":
+                    print(f"warning: {result['name'] or path} — rule {current_item.get('name', '?')!r} has 'except' on a block rule (ignored — except only applies to ask rules)", file=sys.stderr)
+                else:
+                    current_item["except"] = _unquote(stripped[7:].strip())
+
     return result
 
 
@@ -138,6 +144,14 @@ def evaluate_rules(config, cmd):
             continue
         try:
             if re.search(rule["pattern"], cmd):
+                exc = rule.get("except")
+                if exc:
+                    try:
+                        if re.search(exc, cmd):
+                            continue
+                    except re.error as e:
+                        _block(f"{label} — rule {rule.get('name', '?')!r} has invalid 'except' regex: {e}")
+                        continue
                 asks.append(_message(label, rule))
         except re.error as e:
             _block(f"{label} — rule {rule.get('name', '?')!r} has invalid regex: {e}")

--- a/tests/test-engine.sh
+++ b/tests/test-engine.sh
@@ -49,6 +49,43 @@ echo "--- block: missing rules file ---"
 run_test "$TMPDIR_TESTS/nonexistent.yml" "missing file blocks" block \
   '{"tool_name":"Bash","tool_input":{"command":"anything"}}'
 
+echo "--- except bypasses ask but not block ---"
+cat > "$TMPDIR_TESTS/except-test.yml" <<'YAMLEOF'
+name: except-test
+rules:
+  block:
+    - name: dangerous
+      pattern: 'rm.*--no-preserve-root'
+      reason: destroys filesystem
+      ref: n/a
+  ask:
+    - name: rm -rf
+      pattern: 'rm\s+-rf'
+      except: '/tmp/'
+      reason: recursive delete
+      ref: n/a
+YAMLEOF
+run_test "$TMPDIR_TESTS/except-test.yml" "except bypasses ask" allow \
+  '{"tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/build"}}'
+run_test "$TMPDIR_TESTS/except-test.yml" "except does not bypass block" block \
+  '{"tool_name":"Bash","tool_input":{"command":"rm -rf --no-preserve-root /tmp/"}}'
+run_test "$TMPDIR_TESTS/except-test.yml" "ask fires without except match" ask \
+  '{"tool_name":"Bash","tool_input":{"command":"rm -rf ./src"}}'
+
+echo "--- except on block emits warning ---"
+cat > "$TMPDIR_TESTS/except-block-warn.yml" <<'YAMLEOF'
+name: except-block-warn
+rules:
+  block:
+    - name: dangerous
+      pattern: 'rm -rf'
+      except: '/tmp/'
+      reason: destroys stuff
+      ref: n/a
+YAMLEOF
+run_test "$TMPDIR_TESTS/except-block-warn.yml" "except on block still blocks" block \
+  '{"tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/build"}}'
+
 rm -rf "$TMPDIR_TESTS"
 
 echo ""
@@ -68,6 +105,7 @@ run_test "$RULES_DIR" "file block (dir)"    block '{"tool_name":"Bash","tool_inp
 run_test "$RULES_DIR" "file ask (dir)"      ask   '{"tool_name":"Bash","tool_input":{"command":"rm -rf ./build"}}'
 run_test "$RULES_DIR" "secret block (dir)"  block '{"tool_name":"Bash","tool_input":{"command":"cat ~/.ssh/id_rsa"}}'
 run_test "$RULES_DIR" "secret ask (dir)"    ask   '{"tool_name":"Bash","tool_input":{"command":"cat ~/.bashrc"}}'
+run_test "$RULES_DIR" "file except (dir)"    allow '{"tool_name":"Bash","tool_input":{"command":"rm -rf ~/.cache/pip"}}'
 run_test "$RULES_DIR" "safe cmd (dir)"      allow '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}'
 
 print_results

--- a/tests/test-watch-files.sh
+++ b/tests/test-watch-files.sh
@@ -39,6 +39,11 @@ echo "--- ask: chown ---"
 t "chown user"       ask   '{"tool_name":"Bash","tool_input":{"command":"chown www-data:www-data index.html"}}'
 t "sudo chown -R root" ask '{"tool_name":"Bash","tool_input":{"command":"sudo chown -R root /opt"}}'
 
+echo "--- except: cache/temp file deletion ---"
+t "rm -rf cache dir"    allow '{"tool_name":"Bash","tool_input":{"command":"rm -rf ~/.cache/pip"}}'
+t "rm -rf /tmp"         allow '{"tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/build-output"}}'
+t "rm -r /var/tmp"      allow '{"tool_name":"Bash","tool_input":{"command":"rm -r /var/tmp/stale-dir"}}'
+
 echo "--- allow: safe operations ---"
 t "rm single file"   allow '{"tool_name":"Bash","tool_input":{"command":"rm temp.txt"}}'
 t "mv local"         allow '{"tool_name":"Bash","tool_input":{"command":"mv old.txt new.txt"}}'

--- a/tests/test-watch-secrets.sh
+++ b/tests/test-watch-secrets.sh
@@ -15,25 +15,29 @@ echo "--- block: cat cloud credentials ---"
 t "cat .aws/credentials"  block '{"tool_name":"Bash","tool_input":{"command":"cat ~/.aws/credentials"}}'
 t "cat .config/gcloud"    block '{"tool_name":"Bash","tool_input":{"command":"cat ~/.config/gcloud/credentials.json"}}'
 
-echo "--- block: expose secrets ---"
-t "echo SECRET_KEY"        block '{"tool_name":"Bash","tool_input":{"command":"echo $SECRET_KEY"}}'
-t "echo API_KEY"           block '{"tool_name":"Bash","tool_input":{"command":"echo $API_KEY"}}'
-t "printf PASSWORD"        block '{"tool_name":"Bash","tool_input":{"command":"printf \"%s\" $PASSWORD"}}'
-t "cat credentials.json"   block '{"tool_name":"Bash","tool_input":{"command":"cat /app/credentials.json"}}'
-t "head token file"        block '{"tool_name":"Bash","tool_input":{"command":"head ~/.netrc_token"}}'
+echo "--- block: echo secret env var ---"
+t "echo \$SECRET_KEY"     block '{"tool_name":"Bash","tool_input":{"command":"echo $SECRET_KEY"}}'
+t "echo \$API_KEY"        block '{"tool_name":"Bash","tool_input":{"command":"echo $API_KEY"}}'
+t "printf \$PASSWORD"     block '{"tool_name":"Bash","tool_input":{"command":"printf \"%s\" $PASSWORD"}}'
+t "echo \${TOKEN}"        block '{"tool_name":"Bash","tool_input":{"command":"echo ${TOKEN}"}}'
 
-echo "--- block: export secrets inline ---"
-t "export SECRET_KEY="    block '{"tool_name":"Bash","tool_input":{"command":"export SECRET_KEY=abc123"}}'
-t "export API_KEY="       block '{"tool_name":"Bash","tool_input":{"command":"export API_KEY=sk-12345"}}'
-t "export DATABASE_URL="  block '{"tool_name":"Bash","tool_input":{"command":"export DATABASE_URL=postgres://user:pass@host/db"}}'
+echo "--- ask: read files with secret-like names ---"
+t "cat credentials.json"  ask   '{"tool_name":"Bash","tool_input":{"command":"cat /app/credentials.json"}}'
+t "head .netrc_token"     ask   '{"tool_name":"Bash","tool_input":{"command":"head ~/.netrc_token"}}'
+t "cat secrets.md"        ask   '{"tool_name":"Bash","tool_input":{"command":"cat secrets.md"}}'
 
-echo "--- block: cat .env files ---"
-t "cat .env"              block '{"tool_name":"Bash","tool_input":{"command":"cat .env"}}'
-t "cat .env.local"        block '{"tool_name":"Bash","tool_input":{"command":"cat .env.local"}}'
+echo "--- ask: export secrets inline ---"
+t "export SECRET_KEY="    ask   '{"tool_name":"Bash","tool_input":{"command":"export SECRET_KEY=abc123"}}'
+t "export API_KEY="       ask   '{"tool_name":"Bash","tool_input":{"command":"export API_KEY=sk-12345"}}'
+t "export DATABASE_URL="  ask   '{"tool_name":"Bash","tool_input":{"command":"export DATABASE_URL=postgres://user:pass@host/db"}}'
 
-echo "--- block: cat PEM/key files ---"
-t "cat server.pem"        block '{"tool_name":"Bash","tool_input":{"command":"cat server.pem"}}'
-t "cat private.key"       block '{"tool_name":"Bash","tool_input":{"command":"cat private.key"}}'
+echo "--- ask: cat .env files ---"
+t "cat .env"              ask   '{"tool_name":"Bash","tool_input":{"command":"cat .env"}}'
+t "cat .env.local"        ask   '{"tool_name":"Bash","tool_input":{"command":"cat .env.local"}}'
+
+echo "--- ask: cat PEM/key files ---"
+t "cat server.pem"        ask   '{"tool_name":"Bash","tool_input":{"command":"cat server.pem"}}'
+t "cat private.key"       ask   '{"tool_name":"Bash","tool_input":{"command":"cat private.key"}}'
 
 echo "--- ask: env / printenv ---"
 t "env"                   ask   '{"tool_name":"Bash","tool_input":{"command":"env"}}'
@@ -42,6 +46,12 @@ t "printenv"              ask   '{"tool_name":"Bash","tool_input":{"command":"pr
 echo "--- ask: cat dotfiles ---"
 t "cat ~/.bashrc"         ask   '{"tool_name":"Bash","tool_input":{"command":"cat ~/.bashrc"}}'
 t "cat ~/.gitconfig"      ask   '{"tool_name":"Bash","tool_input":{"command":"cat ~/.gitconfig"}}'
+
+echo "--- allow: false-positive prevention (issue #3) ---"
+# Natural-language commit messages with secret keywords must not block or ask
+t "commit msg w/ token"   allow '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"more token handling\""}}'
+t "commit msg w/ secret"  allow '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"fix tail of secret config\""}}'
+t "heredoc commit"        allow '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"head over to docs for password setup\""}}'
 
 echo "--- allow: safe operations ---"
 t "cat normal file"       allow '{"tool_name":"Bash","tool_input":{"command":"cat README.md"}}'


### PR DESCRIPTION
## Context

ClaudeWatch's default rule sets had two usability gaps:

- **#3 — `watch-secrets` was too strict.** The `expose-secrets` rule matched its keyword anywhere in a Bash command, so commit messages with words like "more token handling" hard-blocked, and any read in a path containing "secrets-manager" or "credentials" was rejected. Hard blocks are unrecoverable, which is the wrong tool for these false positives.
- **#4 — No way to exempt safe shapes from ask rules.** Operations like `rm -rf ~/.cache/pip` always prompt because they recursively delete, even though the path is harmless.

This PR addresses both.

## Approach

**Engine — `except` field on ask rules.** Ask rules now support an optional `except: <regex>`. When both `pattern` and `except` match, the rule is skipped. `except` on a block rule is intentionally ignored (with a stderr warning) — block rules are unconditional safety boundaries. This carves out known-safe shapes without weakening the broader rule.

**watch-secrets — replace the overbroad keyword pattern, not just demote it.** The old rule was promoted from block→ask in early drafts, but ask was still noisy on natural-language commit messages. Replaced with two narrower rules:

- **Block** when a print command is fed a shell-expanded variable whose name contains `SECRET`/`TOKEN`/`PASSWORD`/`API_KEY`/`PRIVATE_KEY` — that's the actual exfiltration shape, not just keyword adjacency.
- **Ask** on read commands whose argument is path-shaped (lookahead requires `/`, `~`, or `.` in the same word) and contains one of the keywords. Natural-language text in commit messages no longer matches.

Demoted `export-inline`, `.env`, and PEM/key reads from block to ask (matches the issue author's stance — most should ask, not block). Only SSH keys and cloud credentials remain hard blocks.

**watch-files — apply `except` to the rm rules.** `rm -rf` and `rm -r` ask rules gain an `except` for `~/.cache/`, `/tmp/`, and `/var/tmp/` so routine cleanup no longer prompts.

## Review guide

**5 minutes — the engine change:**
- `scripts/watchdog.py` — the new `except` parsing and skip logic. Small (~12 lines). The whole design lives here.

**10 minutes — add the rule design decisions:**
- `rules/watch-secrets.yml` — the new pattern split. The lookahead `(?=\S*[/~.])` and the variable-expansion shape are the core design calls.
- `rules/watch-files.yml` — sample usage of the new `except` field.

**30 minutes — add tests:**
- `tests/test-engine.sh` — `except` semantics: bypasses ask, ignored on block, ask still fires without an except match.
- `tests/test-watch-secrets.sh` — covers the #3 regressions (commit messages with "tail of secret config", "more token handling" must allow through).
- `tests/test-watch-files.sh` — `except` cases for the cache paths.

**Everything else** — `docs/schema.md` and `CLAUDE.md` document the new field; mechanical.

## Trade-offs

- The new ask rule's lookahead allows `cat secret.txt` to match (no path separator before the keyword, but `.` after). That's intentional — a literal file named "secret.txt" deserves a confirm, not a free pass. If this proves annoying in practice, it can be tightened.
- `except` is regex, not glob. Easier for the engine, but users writing exemptions need to escape `.` and `/`.
- Block rules deliberately reject `except` (warn + ignore). Allowing it would let users silently weaken hard safety boundaries — that's a foot-gun the warning prevents.

## Testing

152 tests pass across all suites. Engine tests verify `except` bypasses ask, does not bypass block, and that ask still fires without an `except` match. Regression tests in `test-watch-secrets.sh` confirm natural-language commit messages no longer match (`git commit -m "more token handling"`, `"fix tail of secret config"`, `"head over to docs for password setup"`).

Closes #3, closes #4.