### PR TITLE
Watch aws

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ClaudeWatch",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "PreToolUse hook that enforces command safety rules via 'claude-watchdog'",
   "author": {
     "name": "chris-peterson"

--- a/.claude/hooks/remind-rules-index.py
+++ b/.claude/hooks/remind-rules-index.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""PostToolUse dev hook — remind to update the secondary rule-set indexes.
+
+Each shipped rule set is described in several hand-maintained places that drift
+independently (README table, SPEC.md [SH-01], help-skill table). This hook fires
+after a Write/Edit to a `rules/watch-*.yml` source file and injects a reminder
+listing those places so a rule-set change doesn't silently leave them stale.
+
+This guards development of ClaudeWatch itself — it is NOT part of the shipped
+plugin (that is `hooks/hooks.json` + `scripts/watchdog.py`). Pure stdlib, exits 0.
+"""
+import json
+import re
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    sys.exit(0)
+
+path = (data.get("tool_input") or {}).get("file_path", "") or ""
+
+# Fire only on rule-set source files — not *.yml.disabled, not test files.
+if not re.search(r"rules/watch-[^/]+\.yml$", path):
+    sys.exit(0)
+
+reminder = (
+    f"Rule-set source changed ({path}). A rule set is described in several "
+    "hand-maintained places that drift independently — update whichever the "
+    "change affects:\n"
+    "  1. README.md — rule-sets table (one row per set)\n"
+    "  2. SPEC.md — [SH-01] enumeration (block/ask coverage prose)\n"
+    "  3. skills/help/SKILL.md — rule-sets table (one-line summary)\n"
+    "  4. tests/test-watch-<name>.sh — add/extend for a new or changed set ([SH-04])\n"
+    "Then run `just test` and `just docs` (regenerates the docs reference from YAML)."
+)
+
+json.dump(
+    {
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": reminder,
+        }
+    },
+    sys.stdout,
+)
+sys.exit(0)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/remind-rules-index.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,15 @@ heredocs, and reordered flags are not bypassable by syntactic tricks.
   applies to ask rules; block rules ignore it with a stderr warning. Use
   `except` to skip prompts on demonstrably-safe variants (`rm -rf /tmp/...`),
   not to make a block rule "softer."
+- **Allow-by-default (deny-list) vs ask-by-default (allow-list).** Most sets
+  are deny-lists: allow-by-default, enumerate the dangerous ops as block/ask —
+  you don't want to prompt on every `git status`. Flip to an allow-list — one
+  broad catch-all `ask` plus an `except` for the safe subset — only when the
+  tool surface is huge and mostly consequential (a cloud control plane), the
+  safe subset is small and cleanly identifiable (AWS `get-`/`list-`/`describe-`/
+  `head-` verbs), and an un-prompted action is costly (spend, data loss, prod
+  change). Litmus test: enumerate the small side. `watch-aws` is the allow-list
+  example; `watch-git` is the deny-list example.
 
 ## Repo conventions
 
@@ -70,9 +79,19 @@ heredocs, and reordered flags are not bypassable by syntactic tricks.
 - **Engine changes** — Update `scripts/watchdog.py` and `tests/test-engine.sh`
   in the same change. The engine has a small surface; every behavior should
   be exercised by a test.
-- **New rule set** — Add `rules/watch-<name>.yml` and `tests/test-watch-<name>.sh`.
-  No `hooks.json` change needed (auto-discovery). Add a row to the README
-  rule-sets table.
+- **New or changed rule set** — Add/edit `rules/watch-<name>.yml` and
+  `tests/test-watch-<name>.sh`. No `hooks.json` change needed (auto-discovery).
+  A rule set is described in three hand-maintained indexes that drift
+  independently — update whichever the change affects:
+  1. `README.md` — rule-sets table (one row per set)
+  2. `SPEC.md` `[SH-01]` — enumeration with block/ask coverage prose
+  3. `skills/help/SKILL.md` — rule-sets table (one-line summary)
+
+  The `docs/_site` reference is generated, not hand-maintained — run `just docs`.
+  A dev-time PostToolUse hook (`.claude/settings.json` →
+  `.claude/hooks/remind-rules-index.py`) emits this same checklist after any
+  `rules/watch-*.yml` Write/Edit so it isn't forgotten; it is not part of the
+  shipped plugin.
 - **Spec changes** — Update `SPEC.md` first. If a code change reveals a spec
   problem (ambiguity, missing requirement), **note it** and resolve via the
   Gap Resolution Protocol (see the spec-driven recipe), don't silently change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.8.0
+
+### Features
+- New `watch-aws` rule set guards AWS CLI operations by reversibility. Unlike the deny-list sets, it takes an allow-list posture: it asks on any mutating `aws <service> <operation>` and stays silent only on read-only commands (`get-`/`list-`/`describe-`/`head-` verbs and `s3 ls`). Irreversible operations are blocked outright — `delete-`/`remove-`/`deregister-`/`terminate-`/`purge-`/`reset-`/`revoke-` verbs, `ec2 release-address`, and the `s3 rm` / `s3 rb` high-level commands. Matching reaches through interspersed global flags (`aws --profile prod ec2 terminate-instances`), and the service token is anchored so a profile or region named like a verb (`--profile delete-prod`) doesn't trip a block.
+- README's "Pairing with Bash permissions" section now covers `aws`: add `Bash(aws *)` to your Claude Code allowlist to make the allowed read-only commands frictionless. It's safe because a hook `ask`/`deny` decision takes precedence over a settings `allow` rule — mutating `aws` commands still prompt and destructive ones still block.
+
+### Other
+- A dev-time PostToolUse hook reminds contributors to update the three hand-maintained rule-set indexes (README table, SPEC `[SH-01]`, help-skill table) whenever a `rules/watch-*.yml` file changes — they previously drifted independently. This guards development of ClaudeWatch itself and is not part of the shipped plugin.
+- `AGENTS.md` documents the deny-list vs allow-list posture choice (when to enumerate dangers vs use a catch-all `ask` + `except`) and expands the "new rule set" checklist to name all three indexes.
+- `SPEC.md`: `watch-aws` recorded in `[SH-01]`; `[FUT-04]` added for the gap that `/ClaudeWatch:rules` edits don't survive plugin upgrades; `DOC-03` (Pages hosting) dropped; `DIST-01` reframed to manifest exposure with hosting out of scope.
+
 ## 0.7.1
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The plugin ships these rule sets, each a standalone YAML file auto-discovered by
 
 | Rule set | File | What it guards |
 | --- | --- | --- |
+| **watch-aws** | `rules/watch-aws.yml` | `aws … delete-`/`remove-`/`deregister-`/`terminate-`/`purge-`/`reset-`/`revoke-` ops, `release-address`, `s3 rm`/`s3 rb` (block); any other `aws` mutating operation (ask). Read-only `get-`/`list-`/`describe-`/`head-` ops and `s3 ls` are allowed. Matches through interspersed global flags (`aws --profile prod ec2 …`) |
 | **watch-bash** | `rules/watch-bash.yml` | `rm -rf /`, `curl \| sh`, `dd of=/dev/sd*`, `mkfs /dev/*`, `shred` (block); `rm -rf` outside cache/tmp paths, `chmod 777`, `chown -R`, shell `eval` of dynamic strings (ask). Applies to `.sh`/`.bash`/`.zsh` file content authored via Write/Edit (bash-target rules for the same primitives live in watch-files) |
 | **watch-dotnet** | `rules/watch-dotnet.yml` | .NET decompilers (`ilspycmd`, `ildasm`, `dotpeek`, `dnspy[ex]`, `justdecompile`), unzip/tar of `.nupkg`, curl/wget of `.nupkg`, and `nuget install` (ask). Nudges toward SourceLink instead of decompiling NuGet packages |
 | **watch-files** | `rules/watch-files.yml` | rm -rf /, chmod 777, shred, mv /dev/null (block); rm -rf, recursive chmod/chown (ask) |
@@ -34,12 +35,17 @@ ClaudeWatch's regex matching reaches anywhere in the command string and into the
 {
   "permissions": {
     "allow": [
-      "Bash(python3 *)",
-      "Bash(pwsh *)"
+      "Bash(aws *)",
+      "Bash(pwsh *)",
+      "Bash(python3 *)"
     ]
   }
 }
 ```
+
+Broadening the allowlist is safe because a hook decision outranks an `allow` rule: ClaudeWatch's `ask` and `deny` still fire even when your allowlist would otherwise let the command through. The allow rule only takes effect where ClaudeWatch stays silent — a silent hook defers to Claude Code's normal permission flow rather than auto-approving.
+
+`watch-aws` leans on this. Unlike the interpreter sets — which stay silent on most commands and only block destructive variants — it *asks* on most `aws` commands and stays silent only on read-only ops (`get-`/`list-`/`describe-`/`head-`, `s3 ls`). `Bash(aws *)` is what makes those reads frictionless; without it they still hit Claude Code's default prompt. Mutations still prompt and destructive ops (`delete-`, `terminate-`, `s3 rm`, …) are still blocked, because the hook's decision wins over the allow rule.
 
 ## The `\n#` gate (and how to work around it)
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -138,12 +138,11 @@ without leaving the session.
 
 - **[DOC-01]** The plugin shall ship a Docsify documentation site under `docs/`.
 - **[DOC-02]** `just docs` shall regenerate the rules-reference page from the YAML rule files.
-- **[DOC-03]** The documentation site shall be published at `https://chris-peterson.github.io/ClaudeWatch/`.
 - **[DOC-04]** The documentation shall include a YAML schema reference covering top-level fields and rule fields.
 
 ## 9. Distribution (DIST)
 
-- **[DIST-01]** The plugin shall be installable via `claude plugin install ClaudeWatch@chris-peterson` from the `chris-peterson` marketplace.
+- **[DIST-01]** The plugin shall expose the metadata required for installation as a Claude Code plugin (name, version, description, repository, license) in its manifest. The mechanism by which the plugin is hosted or distributed (marketplace registration, install command) is out of scope.
 - **[DIST-02]** The plugin shall declare a manifest at `.claude-plugin/plugin.json`.
 - **[DIST-03]** The plugin shall be runnable from a working copy via `claude --plugin-dir .` (no install required for local testing).
 
@@ -153,6 +152,8 @@ These are the rule sets the plugin ships out of the box. Each is
 self-contained and removable by renaming its file to `*.yml.disabled`.
 
 - **[SH-01]** The plugin shall ship the following rule sets:
+
+  - **`watch-aws`** — AWS CLI operations classified by reversibility. **Block** rules shall cover irreversible operations: AWS operations whose verb begins with `delete-`, `remove-`, `deregister-`, `terminate-`, `purge-`, `reset-`, or `revoke-`; the EC2 `release-address` operation; and the `s3` high-level `rm` and `rb` subcommands. A single **ask** rule shall match any other `aws <service> <operation>`, with an `except` that allows read-only operations (`get-`/`list-`/`describe-`/`head-` verb prefixes and the `s3` high-level `ls` subcommand). Rules shall match through interspersed global flags (`-`-prefixed options before the service and between service and operation), including quoted values containing spaces, so that `aws --profile prod ec2 terminate-instances` is not silently bypassed.
 
   - **`watch-bash`** — destructive shell primitives in `.sh`/`.bash`/`.zsh` file content authored via `Write`/`Edit`. File-content only; bash-target coverage for the same primitives lives in `watch-files`. **Block** rules shall cover: `rm -rf /`, `rm -rf /*`, `curl|sh`/`wget|sh`, `dd of=/dev/sd*` (and `nvme`/`disk`/`hd`/`xvd`), `mkfs /dev/...`, and `shred`. **Ask** rules shall cover: recursive `rm -rf` (with `except` for `~/.cache/`, `/tmp/`, `/var/tmp/`, `$TMPDIR`), `chmod 777`, recursive `chown -R`, and shell `eval` of dynamic strings.
 
@@ -208,3 +209,4 @@ These describe how the current implementation satisfies the spec. They are
 - **[FUT-01]** Where a plugin-update self-check is implemented, the SessionStart hook shall verify `watchdog.py` emits the expected `hookSpecificOutput.permissionDecision` schema.
 - **[FUT-02]** Where the user adds a custom rule set via `/ClaudeWatch:rules new`, the skill should offer to scaffold a matching test file in `tests/`.
 - **[FUT-03]** Where multi-line YAML strings or nested anchors are required, the parser may switch to PyYAML; currently the minimal parser does not support these constructs.
+- **[FUT-04]** Where the user customizes rules on an installed plugin via `/ClaudeWatch:rules`, those edits shall survive plugin version upgrades. The skill writes to `${CLAUDE_PLUGIN_ROOT}/rules`, which for an installed plugin resolves to the version-scoped cache directory (e.g. `~/.claude/plugins/cache/chris-peterson/ClaudeWatch/0.7.1/rules/`); an upgrade installs a fresh version directory with its own shipped rules and the hook reads from the new root, orphaning prior edits. A durable customization layer would close this gap — e.g. a user rules directory (such as `~/.config/claudewatch/rules/`) that the engine loads in addition to the shipped set, or a migration step on upgrade. Edits made when running from a working copy via `claude --plugin-dir .` (per [DIST-03]) are already durable because `${CLAUDE_PLUGIN_ROOT}` is the git-tracked checkout, not the cache.

--- a/rules/watch-aws.yml
+++ b/rules/watch-aws.yml
@@ -1,0 +1,61 @@
+name: watch-aws
+filter: '\baws\b'
+
+rules:
+  block:
+    - name: aws delete-*
+      pattern: 'aws(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+[a-z0-9][a-z0-9.-]*(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+delete-'
+      reason: permanently deletes a resource
+      ref: https://docs.aws.amazon.com/cli/latest/reference/
+
+    - name: aws remove-*
+      pattern: 'aws(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+[a-z0-9][a-z0-9.-]*(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+remove-'
+      reason: removes a resource or association
+      ref: https://docs.aws.amazon.com/cli/latest/reference/
+
+    - name: aws deregister-*
+      pattern: 'aws(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+[a-z0-9][a-z0-9.-]*(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+deregister-'
+      reason: deregisters a resource; the prior registration cannot be restored
+      ref: https://docs.aws.amazon.com/cli/latest/reference/
+
+    - name: aws terminate-*
+      pattern: 'aws(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+[a-z0-9][a-z0-9.-]*(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+terminate-'
+      reason: terminates instances or environments; compute and ephemeral storage are destroyed
+      ref: https://docs.aws.amazon.com/cli/latest/reference/ec2/terminate-instances.html
+
+    - name: aws purge-*
+      pattern: 'aws(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+[a-z0-9][a-z0-9.-]*(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+purge-'
+      reason: permanently purges all items (e.g. SQS queue messages)
+      ref: https://docs.aws.amazon.com/cli/latest/reference/sqs/purge-queue.html
+
+    - name: aws reset-*
+      pattern: 'aws(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+[a-z0-9][a-z0-9.-]*(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+reset-'
+      reason: resets settings to defaults; prior values are not recoverable
+      ref: https://docs.aws.amazon.com/cli/latest/reference/
+
+    - name: aws revoke-*
+      pattern: 'aws(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+[a-z0-9][a-z0-9.-]*(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+revoke-'
+      reason: revokes permissions or grants (e.g. security group ingress)
+      ref: https://docs.aws.amazon.com/cli/latest/reference/ec2/revoke-security-group-ingress.html
+
+    - name: aws ec2 release-address
+      pattern: 'aws(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+[a-z0-9][a-z0-9.-]*(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+release-address\b'
+      reason: releases an Elastic IP back to the public pool; the address cannot be reclaimed
+      ref: https://docs.aws.amazon.com/cli/latest/reference/ec2/release-address.html
+
+    - name: aws s3 rm
+      pattern: 'aws(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+s3(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+rm\b'
+      reason: deletes S3 objects with no recovery
+      ref: https://docs.aws.amazon.com/cli/latest/reference/s3/rm.html
+
+    - name: aws s3 rb
+      pattern: 'aws(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+s3(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+rb\b'
+      reason: removes an S3 bucket
+      ref: https://docs.aws.amazon.com/cli/latest/reference/s3/rb.html
+
+  ask:
+    - name: aws mutating operation
+      pattern: 'aws(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+[a-z0-9][a-z0-9.-]*(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+[a-z]'
+      except: 'aws(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+[a-z0-9][a-z0-9.-]*(?:\s+-\S+(?:\s+(?:"[^"]*"|''[^'']*''|[^-\s]\S*))?)*\s+(?:(?:get|list|describe|head)-|ls\b)'
+      reason: mutates AWS resources or state (read-only get/list/describe/head and s3 ls are allowed)
+      ref: https://docs.aws.amazon.com/cli/latest/reference/

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -17,6 +17,7 @@ rules miss.
 
 | Name | Guards |
 |---|---|
+| `watch-aws` | AWS CLI ops by reversibility — `delete-`/`remove-`/`deregister-`/`terminate-`/`purge-`/`reset-`/`revoke-`, `release-address`, `s3 rm`/`rb` (block); other mutating ops (ask); `get-`/`list-`/`describe-`/`head-` and `s3 ls` allowed |
 | `watch-bash` | Shell-script destructive primitives in `.sh`/`.bash`/`.zsh` file content (`rm -rf /`, `curl\|sh`, `dd of=/dev/sd*`, `mkfs`, `shred`, `chmod 777`, `chown -R`) — bash-target coverage lives in `watch-files` |
 | `watch-dotnet` | .NET decompilers, `.nupkg` downloads/extraction, `nuget install` — nudges toward SourceLink |
 | `watch-files` | `rm -rf /`, `chmod 777`, shred, recursive chmod/chown |

--- a/tests/test-watch-aws.sh
+++ b/tests/test-watch-aws.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+source "$(cd "$(dirname "$0")" && pwd)/harness.sh"
+
+RULES="$SCRIPT_DIR/../rules/watch-aws.yml"
+t() { run_test "$RULES" "$@"; }
+
+echo "=== watch-aws ==="
+
+echo "--- block: delete / remove / deregister ---"
+t "delete-bucket"        block '{"tool_name":"Bash","tool_input":{"command":"aws s3api delete-bucket --bucket my-bucket"}}'
+t "delete-stack"         block '{"tool_name":"Bash","tool_input":{"command":"aws cloudformation delete-stack --stack-name prod"}}'
+t "remove-tags"          block '{"tool_name":"Bash","tool_input":{"command":"aws ec2 remove-tags --resources i-123"}}'
+t "deregister-task-def"  block '{"tool_name":"Bash","tool_input":{"command":"aws ecs deregister-task-definition --task-definition app:3"}}'
+
+echo "--- block: terminate / purge / reset / revoke / release-address ---"
+t "terminate-instances"  block '{"tool_name":"Bash","tool_input":{"command":"aws ec2 terminate-instances --instance-ids i-123"}}'
+t "purge-queue"          block '{"tool_name":"Bash","tool_input":{"command":"aws sqs purge-queue --queue-url https://sqs/x"}}'
+t "reset-service-setting" block '{"tool_name":"Bash","tool_input":{"command":"aws ssm reset-service-setting --setting-id x"}}'
+t "revoke-sg-ingress"    block '{"tool_name":"Bash","tool_input":{"command":"aws ec2 revoke-security-group-ingress --group-id sg-1"}}'
+t "release-address"      block '{"tool_name":"Bash","tool_input":{"command":"aws ec2 release-address --allocation-id eipalloc-1"}}'
+
+echo "--- block: s3 high-level rm / rb ---"
+t "s3 rm"                block '{"tool_name":"Bash","tool_input":{"command":"aws s3 rm s3://my-bucket/path --recursive"}}'
+t "s3 rb"                block '{"tool_name":"Bash","tool_input":{"command":"aws s3 rb s3://my-bucket --force"}}'
+
+echo "--- block: through interspersed global flags ---"
+t "global flag before service"   block '{"tool_name":"Bash","tool_input":{"command":"aws --profile prod ec2 terminate-instances --instance-ids i-1"}}'
+t "global flag between svc/op"    block '{"tool_name":"Bash","tool_input":{"command":"aws ec2 --region us-east-1 delete-vpc --vpc-id vpc-1"}}'
+t "quoted-value global flag"      block '{"tool_name":"Bash","tool_input":{"command":"aws --region \"us east 1\" s3api delete-object --bucket b --key k"}}'
+
+echo "--- ask: mutating operations ---"
+t "create-bucket"        ask '{"tool_name":"Bash","tool_input":{"command":"aws s3api create-bucket --bucket new"}}'
+t "run-instances"        ask '{"tool_name":"Bash","tool_input":{"command":"aws ec2 run-instances --image-id ami-1"}}'
+t "put-object"           ask '{"tool_name":"Bash","tool_input":{"command":"aws s3api put-object --bucket b --key k"}}'
+t "update-stack"         ask '{"tool_name":"Bash","tool_input":{"command":"aws cloudformation update-stack --stack-name prod"}}'
+t "modify-instance"      ask '{"tool_name":"Bash","tool_input":{"command":"aws ec2 modify-instance-attribute --instance-id i-1"}}'
+t "start-instances"      ask '{"tool_name":"Bash","tool_input":{"command":"aws ec2 start-instances --instance-ids i-1"}}'
+t "stop-instances"       ask '{"tool_name":"Bash","tool_input":{"command":"aws ec2 stop-instances --instance-ids i-1"}}'
+t "configure set"        ask '{"tool_name":"Bash","tool_input":{"command":"aws configure set region us-east-1"}}'
+
+echo "--- ask: s3 high-level mutating (cp / mv / sync) ---"
+t "s3 cp"                ask '{"tool_name":"Bash","tool_input":{"command":"aws s3 cp file.txt s3://b/k"}}'
+t "s3 sync"              ask '{"tool_name":"Bash","tool_input":{"command":"aws s3 sync ./dist s3://b/site"}}'
+t "s3 mv"                ask '{"tool_name":"Bash","tool_input":{"command":"aws s3 mv a.txt s3://b/a.txt"}}'
+
+echo "--- allow: read-only get / list / describe / head ---"
+t "describe-instances"   allow '{"tool_name":"Bash","tool_input":{"command":"aws ec2 describe-instances"}}'
+t "list-buckets"         allow '{"tool_name":"Bash","tool_input":{"command":"aws s3api list-buckets"}}'
+t "get-object"           allow '{"tool_name":"Bash","tool_input":{"command":"aws s3api get-object --bucket b --key k out.txt"}}'
+t "get-caller-identity"  allow '{"tool_name":"Bash","tool_input":{"command":"aws sts get-caller-identity"}}'
+t "head-object"          allow '{"tool_name":"Bash","tool_input":{"command":"aws s3api head-object --bucket b --key k"}}'
+t "describe w/ profile"  allow '{"tool_name":"Bash","tool_input":{"command":"aws --profile prod ec2 describe-instances --region us-east-1"}}'
+
+echo "--- allow: s3 ls and bare aws ---"
+t "s3 ls"                allow '{"tool_name":"Bash","tool_input":{"command":"aws s3 ls s3://my-bucket/"}}'
+t "aws help"             allow '{"tool_name":"Bash","tool_input":{"command":"aws help"}}'
+t "aws --version"        allow '{"tool_name":"Bash","tool_input":{"command":"aws --version"}}'
+
+echo "--- allow: global-flag value beginning with a blocked verb (regression) ---"
+t "profile named delete-*"   allow '{"tool_name":"Bash","tool_input":{"command":"aws --profile delete-prod ec2 describe-instances"}}'
+t "region named terminate-*" allow '{"tool_name":"Bash","tool_input":{"command":"aws --region terminate-west s3 ls"}}'
+t "profile named reset-*"    allow '{"tool_name":"Bash","tool_input":{"command":"aws --profile reset-foo sts get-caller-identity"}}'
+
+echo "--- block: verb-prefixed flag value still blocks a genuinely destructive op ---"
+t "delete-* profile + terminate" block '{"tool_name":"Bash","tool_input":{"command":"aws --profile delete-prod ec2 terminate-instances --instance-ids i-1"}}'
+
+echo "--- allow: hyphenated service name still reaches its operation ---"
+t "application-autoscaling describe" allow '{"tool_name":"Bash","tool_input":{"command":"aws application-autoscaling describe-scalable-targets --service-namespace ecs"}}'
+t "application-autoscaling delete"   block '{"tool_name":"Bash","tool_input":{"command":"aws application-autoscaling delete-scaling-policy --policy-name p"}}'
+
+echo "--- allow: non-aws and other tools ---"
+t "non-aws command"      allow '{"tool_name":"Bash","tool_input":{"command":"terraform apply"}}'
+t "aws-iam-authenticator" allow '{"tool_name":"Bash","tool_input":{"command":"aws-iam-authenticator token -i cluster"}}'
+t "Write tool"           allow '{"tool_name":"Write","tool_input":{"file_path":"test.txt","content":"hi"}}'
+
+print_results


### PR DESCRIPTION
Closes #9.

## What this does

Adds `watch-aws`, a rule set that classifies AWS CLI commands by reversibility so Claude can't mutate AWS state without approval.

The issue's starting position was "block all," with openness to auto-approving read-only ops. This lands on that second position: read-only commands run silently, **every** mutating command requires approval, and irreversible ops are blocked outright.

| Posture | Commands |
|---|---|
| **Allow** (silent) | read-only verbs `get-`/`list-`/`describe-`/`head-`, plus `s3 ls` |
| **Ask** (approval required) | any other `aws <service> <operation>` — `create-`/`put-`/`update-`/`run-instances`/`s3 cp`/`sync`/… |
| **Block** (un-bypassable) | `delete-`/`remove-`/`deregister-`/`terminate-`/`purge-`/`reset-`/`revoke-` verbs, `ec2 release-address`, `s3 rm`/`s3 rb` |

Matching reaches through interspersed global flags (`aws --profile prod ec2 terminate-instances`) the same way `watch-git` handles git's global flags, and the service token is anchored so a profile or region named like a verb (`--profile delete-prod`) can't trip a block.

This is the first rule set with an **allow-list** posture (ask-by-default, allow the small safe subset) rather than the usual deny-list shape (allow-by-default, enumerate dangers). `AGENTS.md` documents the litmus test for choosing between them.

## Pairing with your permissions

ClaudeWatch abstains rather than auto-allows, so the allowed read-only commands still hit Claude Code's default prompt unless you allowlist them. The README's "Pairing with Bash permissions" section now covers adding `Bash(aws *)` — safe because a hook `ask`/`deny` decision outranks a settings `allow` rule, so mutating commands still prompt and destructive ones still block.

## Also in this PR

- A dev-time PostToolUse hook (`.claude/`) that reminds contributors to update the three hand-maintained rule-set indexes (README table, SPEC `[SH-01]`, help-skill table) on any `rules/watch-*.yml` change. Not part of the shipped plugin.
- `SPEC.md`: `watch-aws` recorded in `[SH-01]`; `[FUT-04]` added for the gap that `/ClaudeWatch:rules` edits don't survive plugin upgrades; `DOC-03` (Pages hosting) dropped; `DIST-01` reframed to manifest exposure with hosting out of scope.
- Version bumped to `0.8.0` with CHANGELOG entry.

## Tests

`tests/test-watch-aws.sh` — 43 cases covering block/ask/allow tiers, interspersed global flags, quoted-value flags, the verb-prefixed-flag-value regression, and hyphenated service names (`application-autoscaling`). Full suite green.
