### PR TITLE
Add decision logging and the learn loop

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ClaudeWatch",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "PreToolUse hook that enforces command safety rules via 'claude-watchdog'",
   "author": {
     "name": "chris-peterson"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,11 @@ heredocs, and reordered flags are not bypassable by syntactic tricks.
 ## Core contracts (don't break these)
 
 1. **Determinism.** Given the same command and the same `rules/` tree, the
-   engine must always produce the same decision. No clocks, no randomness,
-   no network.
+   engine must always produce the same *decision*. No clocks, no randomness,
+   no network on the decision path. Decision logging (`CLAUDEWATCH_LOG`, see
+   [LOG-01]–[LOG-04]) is an opt-in side channel: it stamps a timestamp and
+   writes a file *after* the decision is computed, never feeding back into it.
+   Keep it that way — the clock stays in `_log_event`, not in `evaluate_rules`.
 2. **Exit code is always 0.** A non-zero exit blocks the host (Claude Code)
    from getting a useful decision. All errors are surfaced as `deny` decisions
    with explanatory messages.
@@ -96,6 +99,15 @@ heredocs, and reordered flags are not bypassable by syntactic tricks.
   problem (ambiguity, missing requirement), **note it** and resolve via the
   Gap Resolution Protocol (see the spec-driven recipe), don't silently change
   the implementation.
+
+## Releasing
+
+Releases are cut by bumping `version` in `.claude-plugin/plugin.json` and adding
+a matching `CHANGELOG.md` section, then merging to `main`. This project does
+**not** use git tags or GitHub releases — don't create them, and don't check for
+them to determine release state. The version in `plugin.json` is the source of
+truth; the next release is `current + 1` (minor bump for features, patch for
+fixes).
 
 ## Known constraints (do not paper over)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.9.0
+
+### Features
+- **Decision logging + `/ClaudeWatch:learn`.** Setting `CLAUDEWATCH_LOG` makes the engine append each decision (command, decision, matched rule reasons, timestamp, session, cwd) to a JSONL log. The new `/ClaudeWatch:learn` skill aggregates that log via `scripts/analyze-decisions.py` (read-only, stdlib-only) into a batch of proposed permission changes — promote frequently-allowed commands to your allow list, add `except` clauses to noisy ask rules, and surface blocks that may be in your way — so accumulated prompts are vetted once rather than per command. It works from the hook's own decisions (allowed / asked / blocked) rather than heuristically scanning transcripts. Logging is an opt-in side channel that does not affect the decision (see `SPEC.md` `[LOG-01]`–`[LOG-04]`, `[SK-13]`–`[SK-17]`).
+- Each record also captures the active `permission_mode`. Since the `PreToolUse` hook runs before the permission-mode check, ClaudeWatch's `deny`/`ask` still take effect under `auto` mode — and `/ClaudeWatch:learn` reports `by_mode` and a per-candidate `auto_executed` count, so under auto mode it doubles as an audit of what ran unattended.
+
+### Other
+- `SPEC.md`: new `LOG` category and `[LOG-01]`–`[LOG-04]`; `/ClaudeWatch:learn` recorded in `[SK-13]`–`[SK-17]`. `AGENTS.md` clarifies the determinism contract covers the decision, with logging confined to `_log_event`. Engine logging is exercised by `tests/test-logging.sh`; the analyzer by `tests/test-analyze.sh`.
+
 ## 0.8.0
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ Broadening the allowlist is safe because a hook decision outranks an `allow` rul
 
 `watch-aws` leans on this. Unlike the interpreter sets — which stay silent on most commands and only block destructive variants — it *asks* on most `aws` commands and stays silent only on read-only ops (`get-`/`list-`/`describe-`/`head-`, `s3 ls`). `Bash(aws *)` is what makes those reads frictionless; without it they still hit Claude Code's default prompt. Mutations still prompt and destructive ops (`delete-`, `terminate-`, `s3 rm`, …) are still blocked, because the hook's decision wins over the allow rule.
 
+### Discovering what to allow (`/ClaudeWatch:learn`)
+
+Deciding *which* patterns to add to the allowlist is itself the chore. Set `CLAUDEWATCH_LOG` in the hook environment and the engine appends each decision to a JSONL log:
+
+```jsonc
+// settings.json — the ClaudeWatch hook's env
+{ "env": { "CLAUDEWATCH_LOG": "~/.claude/claudewatch/decisions.jsonl" } }
+```
+
+Then `/ClaudeWatch:learn` aggregates the log into a batch proposal: frequently-allowed commands that aren't in your allowlist yet (promote them), ask rules you keep approving (add an `except`), and blocks that may be in your way. `scripts/analyze-decisions.py` does the read-only analysis; the skill drives the per-item approval. Because it works from the hook's own decisions rather than scanning transcripts heuristically, it distinguishes allowed / asked / blocked instead of guessing what looks read-only. You vet a window's worth of prompts once instead of one at a time.
+
 ## The `\n#` gate (and how to work around it)
 
 Claude Code's built-in Bash input analyzer flags `\n#` (a newline followed by `#`) inside a quoted argument as potentially hiding arguments from path validation. The gate fires **before** any plugin hook runs, so ClaudeWatch never gets a chance to auto-approve. Agents that habitually write multi-line `python3 -c "..."` or `node -e "..."` scripts with embedded `#` comments will get a permission prompt every single invocation, regardless of the allowlist above.

--- a/SPEC.md
+++ b/SPEC.md
@@ -18,9 +18,10 @@ Requirement IDs use `[XX-NN]`. Categories:
 - **RS** — Rule sets (file format, discovery)
 - **RL** — Rules (block, ask, except)
 - **OUT** — Output decisions
+- **LOG** — Decision logging (opt-in side channel)
 - **HK** — Hook wiring
 - **EXT** — Extensibility
-- **SK** — Skills (`/ClaudeWatch:help`, `/ClaudeWatch:rules`)
+- **SK** — Skills (`/ClaudeWatch:help`, `/ClaudeWatch:rules`, `/ClaudeWatch:learn`)
 - **DOC** — Documentation
 - **DIST** — Distribution / install
 - **SH** — Shipped rule sets
@@ -56,6 +57,17 @@ post-edit file content).
 - **[EN-11]** The engine shall not require any third-party Python packages at runtime.
 - **[EN-12]** When evaluating a `Write` input, the engine shall match rules against the value of `tool_input.content`.
 - **[EN-13]** When evaluating an `Edit` input, the engine shall read the file at `tool_input.file_path`, apply the `old_string` → `new_string` substitution (all occurrences if `tool_input.replace_all` is true, otherwise the first occurrence), and match rules against the resulting full content. If the file cannot be read, the engine shall match against `tool_input.new_string` alone.
+
+### Decision logging (LOG)
+
+Logging is an opt-in side channel that records each decision for later review
+(see [SK-13]–[SK-17]). It is separable from the decision: the engine's output
+is identical whether or not logging is enabled.
+
+- **[LOG-01]** Where the `CLAUDEWATCH_LOG` environment variable is set to a non-empty value, the engine shall append one JSON record per evaluated input to that path. The literal value `1` shall select the default path `~/.claude/claudewatch/decisions.jsonl`.
+- **[LOG-02]** When `CLAUDEWATCH_LOG` is unset or empty, the engine shall write no log, and its decision and exit behavior shall be unchanged.
+- **[LOG-03]** Each log record shall include the decision (`allow`/`ask`/`deny`), the matched rule reasons, a UTC timestamp, and the `session_id`, `cwd`, and active `permission_mode` from the hook input. For a `Bash` input the record shall include the command string; for a `Write`/`Edit` input it shall include the target file path rather than the file content.
+- **[LOG-04]** Logging shall not influence the decision and shall not change the process exit code. If a log write fails, then the engine shall report the failure to stderr and otherwise continue, still emitting its decision.
 
 ## 2. Rule Sets (RS)
 
@@ -134,6 +146,18 @@ without leaving the session.
 - **[SK-11]** When the user issues `new`, the skill shall create a new `rules/watch-<name>.yml` (the name shall start with `watch-`) with the standard YAML format.
 - **[SK-12]** After applying changes, the skill shall run `tests/test-watchdog.sh` and shall report any failures.
 
+### `/ClaudeWatch:learn`
+
+The learn skill aggregates the decision log ([LOG-01]–[LOG-04]) into a batch
+of proposed permission changes, so the user vets accumulated prompts once
+rather than per command.
+
+- **[SK-13]** Where the user invokes `/ClaudeWatch:learn`, the skill shall analyze the decision log and present its proposals. If no log exists, the skill shall instruct the user how to enable `CLAUDEWATCH_LOG` and shall make no changes.
+- **[SK-14]** The skill shall present three groups: **allow candidates** (frequently-allowed commands not covered by the current allow list), **ask candidates** (commands ClaudeWatch repeatedly asks about, with the matched rule), and a **deny summary** (blocked commands grouped by reason, informational).
+- **[SK-15]** The skill shall accept an optional time window (e.g. `--since 1d`) and forward it to the analysis.
+- **[SK-16]** Before writing any change, the skill shall present the exact edits and require explicit confirmation, and shall apply only the items the user approves.
+- **[SK-17]** The skill shall apply approved allow-list additions to a `settings.json` whose scope (user or project) the user selects, shall route rule changes (`except` additions, demotions) through `/ClaudeWatch:rules`, and shall not modify deny-summary items automatically.
+
 ## 8. Documentation (DOC)
 
 - **[DOC-01]** The plugin shall ship a Docsify documentation site under `docs/`.
@@ -203,10 +227,17 @@ These describe how the current implementation satisfies the spec. They are
   (`beacon`, `tack`, `logbook`) does not apply here.
 - The rules-skill ID convention strips the `watch-` prefix from the rule set
   name (e.g. `watch-git` → `git-block-01`).
+- Decision logging is implemented in `watchdog.py` as a single `_log_event`
+  call after the decision is computed, guarded by `CLAUDEWATCH_LOG`. The UTC
+  timestamp is the only clock in the script, and it is confined to the logging
+  side channel — the decision path remains clock-free and deterministic.
+- `/ClaudeWatch:learn` reads the log via `scripts/analyze-decisions.py`, a
+  separate read-only, stdlib-only tool. The engine remains the only
+  decision-making component; the analyzer never evaluates rules.
 
 ## 13. Future / Deferred (FUT)
 
 - **[FUT-01]** Where a plugin-update self-check is implemented, the SessionStart hook shall verify `watchdog.py` emits the expected `hookSpecificOutput.permissionDecision` schema.
 - **[FUT-02]** Where the user adds a custom rule set via `/ClaudeWatch:rules new`, the skill should offer to scaffold a matching test file in `tests/`.
 - **[FUT-03]** Where multi-line YAML strings or nested anchors are required, the parser may switch to PyYAML; currently the minimal parser does not support these constructs.
-- **[FUT-04]** Where the user customizes rules on an installed plugin via `/ClaudeWatch:rules`, those edits shall survive plugin version upgrades. The skill writes to `${CLAUDE_PLUGIN_ROOT}/rules`, which for an installed plugin resolves to the version-scoped cache directory (e.g. `~/.claude/plugins/cache/chris-peterson/ClaudeWatch/0.7.1/rules/`); an upgrade installs a fresh version directory with its own shipped rules and the hook reads from the new root, orphaning prior edits. A durable customization layer would close this gap — e.g. a user rules directory (such as `~/.config/claudewatch/rules/`) that the engine loads in addition to the shipped set, or a migration step on upgrade. Edits made when running from a working copy via `claude --plugin-dir .` (per [DIST-03]) are already durable because `${CLAUDE_PLUGIN_ROOT}` is the git-tracked checkout, not the cache.
+- **[FUT-04]** Where the user customizes rules on an installed plugin via `/ClaudeWatch:rules` (including the `except` and demotion edits proposed by `/ClaudeWatch:learn`, which route through that skill), those edits shall survive plugin version upgrades. The skill writes to `${CLAUDE_PLUGIN_ROOT}/rules`, which for an installed plugin resolves to the version-scoped cache directory (e.g. `~/.claude/plugins/cache/chris-peterson/ClaudeWatch/0.8.0/rules/`); an upgrade installs a fresh version directory with its own shipped rules and the hook reads from the new root, orphaning prior edits. The decision log ([LOG-01]) already shows the durable shape: it lives in a fixed user directory (`~/.claude/claudewatch/`) outside the cache and so persists across upgrades. The gap closes by giving rule customizations the same treatment — a user rules directory alongside it (`~/.claude/claudewatch/rules/`) that the engine loads in addition to the shipped set (user rules winning on conflict), or a migration step on upgrade. Until then, only allow-list outputs of `/ClaudeWatch:learn` (written to `settings.json`) are durable on an installed plugin; rule edits are not. Edits made when running from a working copy via `claude --plugin-dir .` (per [DIST-03]) are already durable because `${CLAUDE_PLUGIN_ROOT}` is the git-tracked checkout, not the cache.

--- a/scripts/analyze-decisions.py
+++ b/scripts/analyze-decisions.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""
+analyze-decisions: turn a ClaudeWatch decision log into review proposals.
+
+Reads the JSONL written by watchdog.py when CLAUDEWATCH_LOG is set, groups
+records by command shape, cross-references the current Claude Code allow list,
+and emits a structured proposal the /ClaudeWatch:learn skill renders for
+batch approval.
+
+Three buckets:
+  - allow_candidates  — commands ClaudeWatch allows that are NOT covered by an
+                        allow rule in settings.json, so Claude Code prompts on
+                        them. Promoting these to the allow list removes prompts.
+  - except_candidates — commands ClaudeWatch repeatedly asks about. Candidates
+                        for an `except` (if a safe variant) or for acceptance.
+  - deny_summary      — commands ClaudeWatch blocked, grouped by reason.
+                        Informational: a high count may mean a workflow you
+                        need is blocked.
+
+Read-only, stdlib-only, no network. The allow-pattern match is an approximate
+prefix check (Claude Code's own matcher is the source of truth); it exists only
+to avoid re-proposing commands you already allow.
+"""
+
+import argparse
+import glob
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+
+DEFAULT_LOG = "~/.claude/claudewatch/decisions.jsonl"
+DEFAULT_SETTINGS = "~/.claude/settings.json"
+
+# Tools whose first argument is a subcommand worth keeping in the command shape,
+# so `git push` and `git status` group separately rather than collapsing to `git`.
+SUBCOMMAND_TOOLS = {
+    "git", "gh", "glab", "npm", "npx", "yarn", "pnpm", "pip", "pip3", "cargo",
+    "go", "docker", "kubectl", "just", "make", "brew", "terraform", "bundle",
+    "rake", "dotnet", "aws", "gcloud", "az", "systemctl", "apt", "apt-get",
+    "uv", "poetry", "deno", "bun",
+}
+
+DURATION_UNITS = {"m": "minutes", "h": "hours", "d": "days", "w": "weeks"}
+
+# A subcommand token is a bare lowercase word (e.g. `pr`, `view`, `commit`).
+# Stopping at the first flag, path, or value keeps shapes specific — so a
+# suggested allow pattern stays as narrow as the commands actually run.
+SUBCOMMAND_LIKE = re.compile(r"^[a-z][a-z0-9-]*$")
+MAX_SHAPE_TOKENS = 4
+
+
+def parse_duration(text):
+    """Parse '90m', '2h', '1d', '1w' into a timedelta."""
+    m = re.fullmatch(r"(\d+)\s*([mhdw])", text.strip())
+    if not m:
+        raise ValueError(f"invalid duration {text!r} (use forms like 90m, 2h, 1d, 1w)")
+    return timedelta(**{DURATION_UNITS[m.group(2)]: int(m.group(1))})
+
+
+def load_allow_prefixes(settings_path):
+    """Return a list of (prefix, raw_pattern) from settings.json Bash allow rules.
+
+    Converts `Bash(git push:*)` / `Bash(cat *)` into the literal prefix a command
+    must start with to be considered already-allowed. This is an approximation of
+    Claude Code's matcher, used only to suppress already-allowed suggestions.
+    """
+    path = os.path.expanduser(settings_path)
+    if not os.path.isfile(path):
+        return []
+    with open(path) as f:
+        settings = json.load(f)
+    prefixes = []
+    for rule in settings.get("permissions", {}).get("allow", []):
+        m = re.fullmatch(r"Bash\((.*)\)", rule)
+        if not m:
+            continue
+        inner = m.group(1)
+        prefix = re.split(r":\*|\*", inner, maxsplit=1)[0].rstrip()
+        prefixes.append((prefix, rule))
+    return prefixes
+
+
+def is_already_allowed(command, allow_prefixes):
+    for prefix, _ in allow_prefixes:
+        if prefix and command.startswith(prefix):
+            return True
+    return False
+
+
+def command_shape(command):
+    """Reduce a command to a stable grouping prefix and a suggested allow pattern.
+
+    Skips leading `VAR=value` assignments and `sudo`, then keeps the program and
+    (for known subcommand tools) the subcommand. Returns (shape, allow_pattern).
+    """
+    tokens = command.strip().split()
+    i = 0
+    while i < len(tokens) and (re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", tokens[i]) or tokens[i] == "sudo"):
+        i += 1
+    if i >= len(tokens):
+        return command.strip(), f"Bash({command.strip()})"
+
+    prog = os.path.basename(tokens[i])
+    shape_tokens = [prog]
+    if prog in SUBCOMMAND_TOOLS:
+        j = i + 1
+        while j < len(tokens) and len(shape_tokens) < MAX_SHAPE_TOKENS and SUBCOMMAND_LIKE.match(tokens[j]):
+            shape_tokens.append(tokens[j])
+            j += 1
+
+    shape = " ".join(shape_tokens)
+    return shape, f"Bash({shape}:*)"
+
+
+def read_records(log_path, cutoff):
+    """Yield decision records from the log, optionally filtered to ts >= cutoff."""
+    path = os.path.expanduser(log_path)
+    if not os.path.isfile(path):
+        raise FileNotFoundError(path)
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if cutoff is not None:
+                ts = rec.get("ts")
+                if ts:
+                    try:
+                        when = datetime.fromisoformat(ts)
+                    except ValueError:
+                        when = None
+                    if when is not None and when < cutoff:
+                        continue
+            yield rec
+
+
+def analyze(records, allow_prefixes, min_count, max_samples):
+    allow_groups = defaultdict(lambda: {"count": 0, "samples": [], "cwds": set(), "pattern": None, "auto": 0})
+    ask_groups = defaultdict(lambda: {"count": 0, "samples": [], "reasons": set()})
+    deny_groups = defaultdict(lambda: {"count": 0, "samples": []})
+    by_mode = defaultdict(int)
+
+    for rec in records:
+        by_mode[rec.get("mode") or "unspecified"] += 1
+        decision = rec.get("decision")
+        command = rec.get("command")
+        if not command:
+            continue  # file-content (Write/Edit) records have no command to group
+        shape, pattern = command_shape(command)
+
+        if decision == "allow":
+            if is_already_allowed(command, allow_prefixes):
+                continue
+            g = allow_groups[shape]
+            g["count"] += 1
+            g["pattern"] = pattern
+            if rec.get("mode") == "auto":
+                g["auto"] += 1
+            if rec.get("cwd"):
+                g["cwds"].add(rec["cwd"])
+            if len(g["samples"]) < max_samples and command not in g["samples"]:
+                g["samples"].append(command)
+        elif decision == "ask":
+            g = ask_groups[shape]
+            g["count"] += 1
+            for reason in rec.get("matched", []):
+                g["reasons"].add(reason)
+            if len(g["samples"]) < max_samples and command not in g["samples"]:
+                g["samples"].append(command)
+        elif decision == "deny":
+            for reason in rec.get("matched", []) or ["(unattributed)"]:
+                g = deny_groups[reason]
+                g["count"] += 1
+                if len(g["samples"]) < max_samples and command not in g["samples"]:
+                    g["samples"].append(command)
+
+    allow_candidates = [
+        {"shape": shape, "suggested_allow": g["pattern"], "count": g["count"],
+         "auto_executed": g["auto"], "distinct_dirs": len(g["cwds"]), "samples": g["samples"]}
+        for shape, g in allow_groups.items() if g["count"] >= min_count
+    ]
+    except_candidates = [
+        {"shape": shape, "count": g["count"], "reasons": sorted(g["reasons"]),
+         "samples": g["samples"]}
+        for shape, g in ask_groups.items() if g["count"] >= min_count
+    ]
+    deny_summary = [
+        {"reason": reason, "count": g["count"], "samples": g["samples"]}
+        for reason, g in deny_groups.items()
+    ]
+
+    allow_candidates.sort(key=lambda x: (-x["count"], x["shape"]))
+    except_candidates.sort(key=lambda x: (-x["count"], x["shape"]))
+    deny_summary.sort(key=lambda x: (-x["count"], x["reason"]))
+
+    return {
+        "allow_candidates": allow_candidates,
+        "except_candidates": except_candidates,
+        "deny_summary": deny_summary,
+        "by_mode": dict(by_mode),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Analyze a ClaudeWatch decision log.")
+    parser.add_argument("--log", default=os.environ.get("CLAUDEWATCH_LOG") or DEFAULT_LOG,
+                        help="path to decisions.jsonl (default: $CLAUDEWATCH_LOG or %(default)s)")
+    parser.add_argument("--settings", default=DEFAULT_SETTINGS,
+                        help="path to settings.json for the current allow list")
+    parser.add_argument("--since", default=None,
+                        help="only consider records newer than this (e.g. 1h, 1d, 1w)")
+    parser.add_argument("--min-count", type=int, default=3,
+                        help="minimum occurrences for a command to be proposed (default: 3)")
+    parser.add_argument("--max-samples", type=int, default=5,
+                        help="max sample commands kept per group (default: 5)")
+    args = parser.parse_args()
+
+    if args.log in ("1", "true", "True"):
+        args.log = DEFAULT_LOG
+
+    cutoff = None
+    if args.since:
+        try:
+            cutoff = datetime.now(timezone.utc) - parse_duration(args.since)
+        except ValueError as e:
+            print(f"analyze-decisions: {e}", file=sys.stderr)
+            sys.exit(2)
+
+    try:
+        records = list(read_records(args.log, cutoff))
+    except FileNotFoundError:
+        print(
+            f"analyze-decisions: no decision log at {os.path.expanduser(args.log)}\n"
+            "Enable logging by setting CLAUDEWATCH_LOG in the hook environment, e.g.\n"
+            '  "env": { "CLAUDEWATCH_LOG": "~/.claude/claudewatch/decisions.jsonl" }\n'
+            "in settings.json, then run some sessions before reviewing.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    allow_prefixes = load_allow_prefixes(args.settings)
+    result = analyze(records, allow_prefixes, args.min_count, args.max_samples)
+    result["meta"] = {
+        "log": os.path.expanduser(args.log),
+        "records_considered": len(records),
+        "since": args.since,
+        "min_count": args.min_count,
+    }
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/watchdog.py
+++ b/scripts/watchdog.py
@@ -12,6 +12,10 @@ Supports three tool inputs:
 - Edit: matches against the full post-edit file content reconstructed from
   the on-disk file plus tool_input.old_string -> tool_input.new_string
   substitution (target: file-content rules)
+
+When CLAUDEWATCH_LOG is set, each decision is appended to that path as a JSONL
+record — an opt-in side channel for the /ClaudeWatch:learn workflow that does
+not affect the decision itself.
 """
 
 import glob
@@ -237,6 +241,51 @@ def evaluate_rules(config, input_kind, input_text, file_extension=None):
     return blocks, asks
 
 
+def _log_event(data, input_kind, input_text, decision, matched):
+    """Append a decision record to the log when CLAUDEWATCH_LOG is set.
+
+    Opt-in side channel for the `/ClaudeWatch:learn` workflow. It never
+    influences the decision (which stays a pure function of command + rules)
+    and never changes the exit code. A log-write failure is reported to stderr
+    and swallowed so the hook still returns its decision.
+
+    CLAUDEWATCH_LOG is the destination path; the literal value "1" selects the
+    default path ~/.claude/claudewatch/decisions.jsonl.
+    """
+    dest = os.environ.get("CLAUDEWATCH_LOG")
+    if not dest:
+        return
+    if dest in ("1", "true", "True"):
+        dest = "~/.claude/claudewatch/decisions.jsonl"
+    dest = os.path.expanduser(dest)
+
+    from datetime import datetime, timezone
+
+    entry = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "session": data.get("session_id"),
+        "cwd": data.get("cwd"),
+        "tool": data.get("tool_name"),
+        "mode": data.get("permission_mode"),
+        "decision": decision,
+        "matched": matched,
+    }
+    if input_kind == "bash":
+        entry["command"] = input_text
+    else:
+        tool_input = data.get("tool_input", {}) or {}
+        entry["path"] = tool_input.get("file_path")
+
+    try:
+        parent = os.path.dirname(dest)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(dest, "a") as f:
+            f.write(json.dumps(entry, separators=(",", ":")) + "\n")
+    except OSError as e:
+        print(f"watchdog: failed to write decision log to {dest}: {e}", file=sys.stderr)
+
+
 def _resolve_input(data):
     """Map tool_input -> (input_kind, input_text, file_extension) or None."""
     tool_name = data.get("tool_name")
@@ -327,8 +376,17 @@ def main():
         all_asks.extend(asks)
 
     if all_blocks:
-        _emit("deny", "\n".join(all_blocks))
+        decision, matched = "deny", all_blocks
     elif all_asks:
+        decision, matched = "ask", all_asks
+    else:
+        decision, matched = "allow", []
+
+    _log_event(data, input_kind, input_text, decision, matched)
+
+    if decision == "deny":
+        _emit("deny", "\n".join(all_blocks))
+    elif decision == "ask":
         _emit("ask", "\n".join(all_asks))
 
     sys.exit(0)

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -40,6 +40,8 @@ engine auto-discovers it.
 | `/ClaudeWatch:help` | Show this overview |
 | `/ClaudeWatch:rules` | View and interactively edit rules |
 | `/ClaudeWatch:rules --list` | List rules without entering the edit loop |
+| `/ClaudeWatch:learn` | Learn from the decision log and propose permission changes (cut prompt fatigue) |
+| `/ClaudeWatch:learn --since 1d` | Learn from only the last day's decisions |
 
 ## Decisions
 
@@ -48,6 +50,18 @@ When a Bash invocation matches a rule, the hook emits one of:
 - **block** — command rejected with the rule's reason
 - **ask** — prompt the user to confirm
 - (silent) — no rule matched, command runs normally
+
+## Reducing prompts (watch → learn → suggest)
+
+Set `CLAUDEWATCH_LOG` in the hook environment and the engine records each
+decision to a JSONL log. `/ClaudeWatch:learn` reads that log and proposes a
+batch of permission changes: promote frequently-allowed commands to your allow
+list, add `except` clauses to noisy ask rules, and surface blocks that may be
+in your way. You vet accumulated prompts once instead of per command.
+
+```json
+{ "env": { "CLAUDEWATCH_LOG": "~/.claude/claudewatch/decisions.jsonl" } }
+```
 
 ## Docs
 

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -1,0 +1,124 @@
+---
+description: >
+  Learn from the ClaudeWatch decision log and propose permission changes that
+  cut prompt fatigue — promote frequently-allowed commands to your allow list,
+  add `except` clauses to noisy ask rules, and surface blocks that may be in
+  your way. Invoke with /ClaudeWatch:learn, optionally with a window like
+  `--since 1d`. Triggers on "what keeps prompting me", "tune my watches",
+  "reduce prompts", "learn from my sessions".
+---
+
+# ClaudeWatch — learn
+
+ClaudeWatch watches every command and records its decision; this skill is the
+*learn* step that turns those recordings into suggestions. You vet a window's
+worth of accumulated prompts once, as a batch, instead of pressing enter on
+each one. It is the replacement for the generic transcript-scanning approach:
+it works from the hook's own decisions, so it knows what ClaudeWatch allowed,
+asked, and blocked — not just what looked read-only.
+
+## 0. Prerequisite: logging must be on
+
+The hook only records when `CLAUDEWATCH_LOG` is set in its environment. Check
+whether a log exists:
+
+```bash
+ls -la "${CLAUDEWATCH_LOG:-$HOME/.claude/claudewatch/decisions.jsonl}"
+```
+
+If it does not exist, logging is off. Tell the user to add an `env` block to
+the ClaudeWatch hook environment (user `settings.json`) and restart their
+sessions:
+
+```json
+{ "env": { "CLAUDEWATCH_LOG": "~/.claude/claudewatch/decisions.jsonl" } }
+```
+
+Then stop — there is nothing to learn from until sessions have run with logging
+on.
+
+## 1. Run the analyzer
+
+Forward any window argument the user passed (`--since 1d`, `--since 4h`). The
+analyzer is read-only and emits JSON:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/analyze-decisions.py" --since 1d
+```
+
+Useful flags: `--min-count N` (default 3) sets how many times a command must
+recur before it is proposed; `--settings PATH` points at a different
+`settings.json`; `--log PATH` reads a different log.
+
+## 2. Present the three buckets
+
+Render the JSON as three tables. Lead with the one that removes the most
+prompts.
+
+- **Allow candidates** — commands ClaudeWatch already allows that are *not*
+  covered by your allow list, so Claude Code prompts on them. Columns: shape,
+  count, distinct dirs, suggested `allow` pattern. These are the prompt-fatigue
+  wins.
+- **Ask candidates** — commands ClaudeWatch repeatedly *asks* about. Columns:
+  shape, count, the matched rule(s). For each, the choice is: add an `except`
+  for a demonstrably-safe variant, or leave it (the prompt is doing its job).
+- **Deny summary** — commands ClaudeWatch *blocked*, grouped by reason.
+  Informational. A high count means a workflow you need is blocked — worth a
+  conversation, never an automatic change.
+
+## 3. Let the user choose, then confirm
+
+Ask which items to apply. For the **allow candidates**, confirm the scope:
+
+- **User** (`~/.claude/settings.json`) — applies to every session.
+- **Project** (`.claude/settings.json` in the repo) — applies to that repo only.
+
+Each suggested pattern is conservative (as narrow as the commands actually
+run). Offer to widen or narrow any pattern before writing. Before writing,
+show the exact `permissions.allow` additions and get an explicit `yes`.
+
+Apply by reading the chosen `settings.json`, appending the approved patterns to
+`permissions.allow` (creating the keys if absent, de-duplicating), and writing
+it back. Do not reorder or drop existing entries.
+
+> If the user keeps their `settings.json` under external management (synced from
+> another source rather than hand-edited), do not edit `~/.claude/settings.json`
+> directly — show them the patches to apply at their source instead.
+
+## 4. Ask candidates → rule changes
+
+For approved **ask candidates**, the change is an `except` on the matched rule
+(to stop prompting on a safe variant) — that is a rule edit, so route it
+through `/ClaudeWatch:rules`, which validates and previews. Name the rule (the
+`matched` reason identifies the set) and the `except` regex to add. Do not
+hand-edit shipped rule YAML from this skill.
+
+## 5. Deny summary → never automatic
+
+Surface blocked-command counts so the user sees what is in their way, but make
+no change. If a block is genuinely unwanted, that is a deliberate rule decision
+for `/ClaudeWatch:rules` (demote block → ask) or a spec discussion — not a
+side effect of a learn pass. A frequently-allowed but consequential command in
+the *allow* bucket (e.g. `terraform apply`) is the inverse signal: a coverage
+gap where a new ask rule may belong.
+
+## Auto mode
+
+ClaudeWatch's `PreToolUse` hook runs *before* the permission-mode check, so its
+`deny` still blocks and `ask` still prompts even under `auto` or
+`bypassPermissions`. Each record carries the active `mode`, and the analyzer
+reports `by_mode` plus an `auto_executed` count per allow candidate. Under auto
+mode the prompts are already gone, so this skill's value shifts from *cutting
+prompts* to *auditing what ran unattended*: lead with the high-`auto_executed`
+allow candidates ("these ran N times with no review — keep allowing, or add a
+watch rule?") and treat the deny summary as the record of what the hard backstop
+caught while you weren't watching.
+
+## Notes
+
+- The analyzer's allow-list match is an approximate prefix check; Claude Code's
+  own matcher is the source of truth. Its only job is to avoid re-proposing
+  commands you already allow.
+- `command_shape` groups by program plus its leading subcommand tokens, so
+  `gh pr view` and `gh pr merge` are distinct candidates — promoting one does
+  not silently allow the other.

--- a/tests/test-analyze.sh
+++ b/tests/test-analyze.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Decision-log analyzer (scripts/analyze-decisions.py). Builds a synthetic log
+# plus a stub allow list and asserts the three proposal buckets.
+source "$(cd "$(dirname "$0")" && pwd)/harness.sh"
+
+ANALYZE="$SCRIPT_DIR/../scripts/analyze-decisions.py"
+
+echo "=== decision log analysis ==="
+
+TMP=$(mktemp -d /tmp/cw-analyze.XXXXXX)
+LOG="$TMP/decisions.jsonl"
+SETTINGS="$TMP/settings.json"
+OUT="$TMP/out.json"
+
+# Allow list already covers jq, so jq must NOT be re-proposed.
+cat > "$SETTINGS" <<'EOF'
+{"permissions":{"allow":["Bash(jq:*)"]}}
+EOF
+
+# Synthetic log:
+#   gh pr view  x4  allow, not allow-listed   -> allow_candidate
+#   jq          x3  allow, allow-listed       -> suppressed
+#   git commit  x3  ask                       -> except_candidate
+#   force push  x2  deny                      -> deny_summary
+cat > "$LOG" <<'EOF'
+{"ts":"2026-05-31T10:00:00+00:00","decision":"allow","tool":"Bash","mode":"auto","command":"gh pr view 1","cwd":"/a"}
+{"ts":"2026-05-31T10:01:00+00:00","decision":"allow","tool":"Bash","mode":"auto","command":"gh pr view 2","cwd":"/a"}
+{"ts":"2026-05-31T10:02:00+00:00","decision":"allow","tool":"Bash","mode":"auto","command":"gh pr view 3","cwd":"/b"}
+{"ts":"2026-05-31T10:03:00+00:00","decision":"allow","tool":"Bash","mode":"default","command":"gh pr view 4","cwd":"/b"}
+{"ts":"2026-05-31T10:04:00+00:00","decision":"allow","tool":"Bash","command":"jq .x a.json","cwd":"/a"}
+{"ts":"2026-05-31T10:05:00+00:00","decision":"allow","tool":"Bash","command":"jq .y b.json","cwd":"/a"}
+{"ts":"2026-05-31T10:06:00+00:00","decision":"allow","tool":"Bash","command":"jq .z c.json","cwd":"/a"}
+{"ts":"2026-05-31T10:07:00+00:00","decision":"ask","tool":"Bash","command":"git commit -m a","matched":["watch-git — git commit"],"cwd":"/a"}
+{"ts":"2026-05-31T10:08:00+00:00","decision":"ask","tool":"Bash","command":"git commit -m b","matched":["watch-git — git commit"],"cwd":"/a"}
+{"ts":"2026-05-31T10:09:00+00:00","decision":"ask","tool":"Bash","command":"git commit -m c","matched":["watch-git — git commit"],"cwd":"/a"}
+{"ts":"2026-05-31T10:10:00+00:00","decision":"deny","tool":"Bash","command":"git push --force origin main","matched":["watch-git — force push"],"cwd":"/a"}
+{"ts":"2026-05-31T10:11:00+00:00","decision":"deny","tool":"Bash","command":"git push --force origin dev","matched":["watch-git — force push"],"cwd":"/a"}
+EOF
+
+assert_json() {
+  local label="$1" expr="$2"
+  TOTAL=$((TOTAL + 1))
+  if python3 -c "
+import json,sys
+d=json.load(open(sys.argv[1]))
+sys.exit(0 if ($expr) else 1)
+" "$OUT" 2>/dev/null; then
+    PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC}: $label"
+  else
+    FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC}: $label"
+  fi
+}
+
+python3 "$ANALYZE" --log "$LOG" --settings "$SETTINGS" --min-count 2 > "$OUT" 2>/dev/null
+
+assert_json "gh pr view is an allow candidate (count 4)" \
+  "any(c['shape']=='gh pr view' and c['count']==4 for c in d['allow_candidates'])"
+assert_json "gh pr view suggests Bash(gh pr view:*)" \
+  "any(c['shape']=='gh pr view' and c['suggested_allow']=='Bash(gh pr view:*)' for c in d['allow_candidates'])"
+assert_json "gh pr view shows 3 auto-executed of 4" \
+  "any(c['shape']=='gh pr view' and c['auto_executed']==3 for c in d['allow_candidates'])"
+assert_json "by_mode tallies auto and default" \
+  "d['by_mode'].get('auto')==3 and d['by_mode'].get('default')==1"
+assert_json "allow-listed jq is suppressed" \
+  "all(c['shape']!='jq' for c in d['allow_candidates'])"
+assert_json "git commit is an except candidate (count 3)" \
+  "any(c['shape']=='git commit' and c['count']==3 for c in d['except_candidates'])"
+assert_json "force push appears in deny summary (count 2)" \
+  "any('force push' in s['reason'] and s['count']==2 for s in d['deny_summary'])"
+
+echo "--- min-count filters low-frequency shapes ---"
+python3 "$ANALYZE" --log "$LOG" --settings "$SETTINGS" --min-count 5 > "$OUT" 2>/dev/null
+assert_json "gh pr view (count 4) dropped at min-count 5" \
+  "all(c['shape']!='gh pr view' for c in d['allow_candidates'])"
+
+echo "--- missing log exits non-zero with guidance ---"
+TOTAL=$((TOTAL + 1))
+if python3 "$ANALYZE" --log "$TMP/nope.jsonl" --settings "$SETTINGS" >/dev/null 2>&1; then
+  FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC}: missing log should exit non-zero"
+else
+  PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC}: missing log exits non-zero"
+fi
+
+rm -f "$LOG" "$SETTINGS" "$OUT"
+rmdir "$TMP" 2>/dev/null || true
+
+print_results

--- a/tests/test-logging.sh
+++ b/tests/test-logging.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Engine decision logging (CLAUDEWATCH_LOG). Logging is an opt-in side channel
+# that must not change the emitted decision or the exit code.
+source "$(cd "$(dirname "$0")" && pwd)/harness.sh"
+
+echo "=== decision logging (CLAUDEWATCH_LOG) ==="
+
+# Run the hook with CLAUDEWATCH_LOG set, then assert the last logged record's
+# "decision" field matches what the rules produce for the input.
+log_decision_test() {
+  local label="$1" expected_decision="$2" input="$3"
+  local logfile
+  logfile=$(mktemp /tmp/cw-log.XXXXXX.jsonl)
+  TOTAL=$((TOTAL + 1))
+  echo "$input" | CLAUDEWATCH_LOG="$logfile" python3 "$HOOK" "$RULES_DIR" >/dev/null 2>&1 || true
+  local got
+  got=$(python3 -c 'import json,sys; print(json.loads(open(sys.argv[1]).read().splitlines()[-1])["decision"])' "$logfile" 2>/dev/null || true)
+  rm -f "$logfile"
+  if [ "$got" = "$expected_decision" ]; then
+    PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC}: $label"
+  else
+    FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC}: $label (expected decision=$expected_decision, logged: ${got:-none})"
+  fi
+}
+
+log_decision_test "allow decision is logged" allow '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}'
+log_decision_test "ask decision is logged"   ask   '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"x\""}}'
+log_decision_test "deny decision is logged"  deny  '{"tool_name":"Bash","tool_input":{"command":"git push --force origin main"}}'
+
+echo "--- logged record carries the command verbatim ---"
+LOGFILE=$(mktemp /tmp/cw-cmd.XXXXXX.jsonl)
+echo '{"tool_name":"Bash","tool_input":{"command":"ls -la /etc"}}' \
+  | CLAUDEWATCH_LOG="$LOGFILE" python3 "$HOOK" "$RULES_DIR" >/dev/null 2>&1 || true
+TOTAL=$((TOTAL + 1))
+if python3 -c 'import json,sys; sys.exit(0 if json.loads(open(sys.argv[1]).read().splitlines()[-1]).get("command")=="ls -la /etc" else 1)' "$LOGFILE" 2>/dev/null; then
+  PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC}: command recorded in log"
+else
+  FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC}: command recorded in log"
+fi
+rm -f "$LOGFILE"
+
+echo "--- logged record carries the matched rule reasons for ask/deny ---"
+LOGFILE=$(mktemp /tmp/cw-matched.XXXXXX.jsonl)
+echo '{"tool_name":"Bash","tool_input":{"command":"git push --force origin main"}}' \
+  | CLAUDEWATCH_LOG="$LOGFILE" python3 "$HOOK" "$RULES_DIR" >/dev/null 2>&1 || true
+TOTAL=$((TOTAL + 1))
+if python3 -c 'import json,sys; rec=json.loads(open(sys.argv[1]).read().splitlines()[-1]); sys.exit(0 if rec["decision"]=="deny" and len(rec.get("matched",[]))>=1 else 1)' "$LOGFILE" 2>/dev/null; then
+  PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC}: matched reasons recorded for deny"
+else
+  FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC}: matched reasons recorded for deny"
+fi
+rm -f "$LOGFILE"
+
+echo "--- logged record carries the active permission_mode ---"
+LOGFILE=$(mktemp /tmp/cw-mode.XXXXXX.jsonl)
+echo '{"tool_name":"Bash","tool_input":{"command":"ls -la"},"permission_mode":"auto"}' \
+  | CLAUDEWATCH_LOG="$LOGFILE" python3 "$HOOK" "$RULES_DIR" >/dev/null 2>&1 || true
+TOTAL=$((TOTAL + 1))
+if python3 -c 'import json,sys; sys.exit(0 if json.loads(open(sys.argv[1]).read().splitlines()[-1]).get("mode")=="auto" else 1)' "$LOGFILE" 2>/dev/null; then
+  PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC}: permission_mode recorded in log"
+else
+  FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC}: permission_mode recorded in log"
+fi
+rm -f "$LOGFILE"
+
+echo "--- no log written when CLAUDEWATCH_LOG is unset ---"
+NOLOG=$(mktemp -u /tmp/cw-nolog.XXXXXX.jsonl)
+TOTAL=$((TOTAL + 1))
+# env -u guards against an exported CLAUDEWATCH_LOG leaking in from the parent shell.
+echo '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}' \
+  | env -u CLAUDEWATCH_LOG python3 "$HOOK" "$RULES_DIR" >/dev/null 2>&1 || true
+if [ ! -e "$NOLOG" ]; then
+  PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC}: no log file created when env unset"
+else
+  FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC}: no log file created when env unset"
+  rm -f "$NOLOG"
+fi
+
+print_results

--- a/tests/test-watchdog.sh
+++ b/tests/test-watchdog.sh
@@ -12,7 +12,7 @@ echo "========================================"
 echo "  claude-watchdog tests"
 echo "========================================"
 
-for test_file in "$SCRIPT_DIR"/test-watch-*.sh "$SCRIPT_DIR"/test-engine.sh; do
+for test_file in "$SCRIPT_DIR"/test-watch-*.sh "$SCRIPT_DIR"/test-engine.sh "$SCRIPT_DIR"/test-logging.sh "$SCRIPT_DIR"/test-analyze.sh; do
   echo ""
   if bash "$test_file"; then
     :


### PR DESCRIPTION
## Context

ClaudeWatch is a `PreToolUse` hook that applies regex safety rules to every
Bash/Write/Edit and returns allow / ask / deny. The engine keeps no record of
what it decides, so there's no feedback loop for tuning which prompts a user
actually faces day to day.

Issue #11 asked for exactly that loop: catalog the hook's decisions, log the
false positives (prompts that shouldn't have fired), and feed it back to improve
the tool. This adds the watch → learn → suggest loop.

```mermaid
%%{ init: { 'look': 'handDrawn' } }%%
flowchart LR
    Hook["PreToolUse hook"] --> Decide["allow / ask / deny"]
    Decide --> Log["decisions.jsonl"]
    Log --> Learn["/ClaudeWatch:learn"]
    Learn --> Propose["batched proposal"]
    Propose --> Allow["promote to allow list"]
    Propose --> Except["add except to noisy ask rule"]
    Propose --> Deny["surface blocks in your way"]
```

Logging is opt-in (`CLAUDEWATCH_LOG`); `/ClaudeWatch:learn` turns the log into a
batch you vet once instead of one prompt at a time. Closes #11 — the
crowdsourced one-click-MR idea from the issue stays a follow-up.

## Review guide

**Critical path**
- [`scripts/watchdog.py:244`](https://github.com/chris-peterson/ClaudeWatch/pull/13/files#diff-1534602ba772e4d20b71b0ec537f6f78c2ae4973cc5580cfec582ae46c384ec9R244) — `_log_event`, the opt-in side channel
- [`scripts/watchdog.py:385`](https://github.com/chris-peterson/ClaudeWatch/pull/13/files#diff-1534602ba772e4d20b71b0ec537f6f78c2ae4973cc5580cfec582ae46c384ec9R385) — call site: the decision is computed first, so logging can't change it or the exit code
- [`scripts/analyze-decisions.py:145`](https://github.com/chris-peterson/ClaudeWatch/pull/13/files#diff-3aa1f13bd3ce8fb1ee7e5f95595b678377353ffec30270c74fee6f50ef19291fR145) — `analyze()`: buckets the log into allow / except / deny + `by_mode`
- [`scripts/analyze-decisions.py:94`](https://github.com/chris-peterson/ClaudeWatch/pull/13/files#diff-3aa1f13bd3ce8fb1ee7e5f95595b678377353ffec30270c74fee6f50ef19291fR94) — `command_shape()`: how a suggested allow pattern is built (narrow by design — `gh pr view` ≠ `gh pr merge`)

**Integration**
- [`skills/learn/SKILL.md`](https://github.com/chris-peterson/ClaudeWatch/pull/13/files#diff-0c4a7d091d67865f981ac2420acb6d039225e114ee8e108fdbd9bddf64a4a036) — the interactive layer; drives per-item approval, routes rule edits through `/ClaudeWatch:rules`, never auto-edits

**Tests**
- [`tests/test-logging.sh`](https://github.com/chris-peterson/ClaudeWatch/pull/13/files#diff-57e9ca91fdd083dd91bc101e736ff0e3f8505ce89c6a16cba940f496d79764f1) — logging on/off, decision unchanged, `mode` captured
- [`tests/test-analyze.sh`](https://github.com/chris-peterson/ClaudeWatch/pull/13/files#diff-bb1a2cb6153eccdad36d96e1d2d143db8f8af90f27bd948a717f6183f405af6e) — bucketing, allow-list suppression, `by_mode` tally

**Docs / mechanical** — skim: [`SPEC.md`](https://github.com/chris-peterson/ClaudeWatch/pull/13/files#diff-7426c9e3a694ca6015df5f98637912975f2edea23270203ee89a8bdeed246ee0) (`LOG-01`–`LOG-04`, `SK-13`–`SK-17`, `FUT-04`), [`README.md`](https://github.com/chris-peterson/ClaudeWatch/pull/13/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), CHANGELOG, AGENTS "Releasing" note, `plugin.json` → `0.9.0`

## Approach & trade-offs

- **Logging can't change the decision.** It's gated on `CLAUDEWATCH_LOG` and runs *after* the decision is computed; the decision path stays clock-free and deterministic, exit code is always `0`, and a log-write failure goes to stderr and is swallowed (core contracts in `AGENTS.md`).
- **The engine stays the only decision-maker.** Analysis lives in a separate read-only script that never evaluates rules. Its allow-list match is an approximate prefix check — Claude Code's matcher is the source of truth; the check exists only to avoid re-proposing commands you already allow.
- **Auto mode.** The hook runs before the permission-mode check, so `deny`/`ask` still fire under `auto`; recording `permission_mode` lets `/learn` double as an audit of what ran unattended.

## Testing

`tests/test-watchdog.sh` covers logging and the analyzer. One caveat worth a reviewer's eye: the `permission_mode` field name comes from the Claude Code docs, not from an observed hook payload — `_log_event` reads it defensively (records `null` if absent), so the first real log line will confirm the field name.