### PR TITLE
Portable hook launchers and Windows platform scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,97 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  # The full bash test suite on Unix — the canonical gate.
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+      - name: Run the watchdog test suite
+        run: bash tests/test-watchdog.sh
+
+  # Native-Windows evidence ([PL-01a]). The Git Bash vs PowerShell dispatch
+  # question can't be answered from a non-Windows dev host, so the runner
+  # exercises BOTH launcher paths plus the engine directly. Each step is the
+  # actual proof for one acceptance criterion: interpreter resolution, a
+  # PreToolUse decision, the loud-failure path, and SessionStart emission.
+  windows:
+    runs-on: windows-latest
+    env:
+      CLAUDE_PLUGIN_ROOT: ${{ github.workspace }}
+      CLAUDEWATCH_LOG: 'off'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      # Confirm the interpreter names the launchers probe for. setup-python
+      # provides `python`; the py.exe launcher ships with Windows Python.
+      - name: Report available Python interpreters
+        shell: pwsh
+        run: |
+          foreach ($i in @('python3','python','py')) {
+            $c = Get-Command $i -ErrorAction SilentlyContinue
+            if ($c) { Write-Host "$i -> $($c.Source)" } else { Write-Host "$i -> (absent)" }
+          }
+
+      # The engine runs directly under Windows Python and produces a decision.
+      - name: Engine produces a deny under Windows Python
+        shell: pwsh
+        run: |
+          $block = '{"tool_name":"Bash","tool_input":{"command":"git push --force origin main"}}'
+          $out = $block | python scripts/watchdog.py watches
+          if ($out -match '"permissionDecision":"deny"') { Write-Host "OK: deny" }
+          else { Write-Error "expected deny, got: $out"; exit 1 }
+
+      # PowerShell launcher path (native Windows without Git Bash) — resolves an
+      # interpreter and forwards the engine's decision.
+      - name: PowerShell launcher resolves and decides
+        shell: pwsh
+        run: |
+          $block = '{"tool_name":"Bash","tool_input":{"command":"git push --force origin main"}}'
+          $out = $block | pwsh -File hooks/run-watchdog.ps1
+          if ($out -match '"permissionDecision":"deny"') { Write-Host "OK: deny via ps1 launcher" }
+          else { Write-Error "ps1 launcher: expected deny, got: $out"; exit 1 }
+
+      # PowerShell launcher fails loudly with no fabricated decision when no
+      # interpreter resolves ([PL-02], [PL-03]).
+      - name: PowerShell launcher fails loud on no interpreter
+        shell: pwsh
+        run: |
+          # Resolve pwsh first, then hand the child a PATH with no interpreter on
+          # it (a nonexistent dir, not empty — empty PATH falls back to a default
+          # on some hosts). Invoking pwsh by absolute path keeps the launcher's
+          # own shell findable while the probe finds no python/py.
+          $pwsh = (Get-Command pwsh).Source
+          $block = '{"tool_name":"Bash","tool_input":{"command":"git push --force origin main"}}'
+          $stdout = $block | & {
+            $env:PATH = "C:\nonexistent-claudewatch"
+            & $pwsh -NoProfile -File hooks/run-watchdog.ps1 2>$null
+          }
+          $rc = $LASTEXITCODE
+          if ($rc -eq 0) { Write-Error "expected non-zero exit, got 0"; exit 1 }
+          if ([string]::IsNullOrEmpty($stdout)) { Write-Host "OK: no fabricated decision, rc=$rc" }
+          else { Write-Error "launcher fabricated output: $stdout"; exit 1 }
+
+      # Bash launcher path (Git Bash, which windows-latest provides). The full
+      # launcher test asserts resolution, allow-by-silence, and the loud-failure
+      # path; running it here proves the bash path on Windows too.
+      - name: Bash launcher and SessionStart scripts under Git Bash
+        shell: bash
+        run: |
+          bash tests/test-launcher.sh
+          out=$(CLAUDE_PLUGIN_ROOT="$GITHUB_WORKSPACE" bash hooks/emit-rules.sh)
+          echo "$out" | grep -qF "# Ambient rules from the ClaudeWatch plugin" \
+            && echo "OK: SessionStart emit-rules emits" \
+            || { echo "emit-rules did not emit the header"; exit 1; }
+          CLAUDE_PLUGIN_ROOT="$GITHUB_WORKSPACE" bash hooks/cli-freshness.sh \
+            && echo "OK: SessionStart cli-freshness runs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,9 @@ jobs:
           }
           $rc = $LASTEXITCODE
           if ($rc -eq 0) { Write-Error "expected non-zero exit, got 0"; exit 1 }
-          if ([string]::IsNullOrEmpty($stdout)) { Write-Host "OK: no fabricated decision, rc=$rc" }
+          # The probe above intentionally left $LASTEXITCODE non-zero; reset it
+          # with an explicit `exit 0` so the leaked code doesn't fail the step.
+          if ([string]::IsNullOrEmpty($stdout)) { Write-Host "OK: no fabricated decision, rc=$rc"; exit 0 }
           else { Write-Error "launcher fabricated output: $stdout"; exit 1 }
 
       # Bash launcher path (Git Bash, which windows-latest provides). The full

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,11 +152,23 @@ what `claude plugin update` reads.
 
 ## Known constraints (do not paper over)
 
+- **Supported platforms are macOS, Linux, and Windows, including genuine native
+  Windows** (PowerShell/cmd, not only WSL or Git Bash). See the Platforms
+  section ([PL-01]–[PL-05]) in `SPEC.md`. The hook entries invoke portable
+  launchers (`hooks/run-watchdog.sh` and `hooks/run-watchdog.ps1`) that probe
+  `python3`/`python`/`py` rather than naming an interpreter directly, so the
+  cross-platform logic lives in the wiring and the engine stays generic. Which
+  shell native Windows dispatches the hook through (Git Bash vs PowerShell) is
+  the issue's open acceptance criterion; it can't be verified from a macOS/Linux
+  host, so both launcher paths are shipped and `.github/workflows/ci.yml`
+  exercises each on a `windows-latest` runner ([PL-01a]) — the CI run is the
+  evidence. The decision log's owner-only guarantee is degraded on Windows
+  (`chmod` honors only the read-only bit — [PL-04]/[LOG-05]), documented rather
+  than worked around.
 - **macOS-style absolute paths** appear in shipped rules (`~/.ssh/...`,
-  `~/.aws/credentials`). These are user-home patterns, not platform-specific
-  per se — but the documentation references unix conventions. If
-  cross-platform support becomes a goal, that's a spec change, not a quick
-  fix.
+  `~/.aws/credentials`). These are user-home patterns. The engine matches the
+  command string regardless of OS, so they are not wrong on Windows — they just
+  rarely fire for a user working in PowerShell or cmd ([PL-05]).
 - **`SessionStart` hook is a no-op placeholder.** `hooks/cli-freshness.sh`
   exists for symmetry across the chris-peterson plugin namespace and to
   reserve a spot for future plugin-update self-checks. Do not delete it

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Deciding *which* patterns to add to the allowlist is itself the chore. The engin
 { "env": { "CLAUDEWATCH_LOG": "~/.claude/claudewatch/decisions.jsonl" } }
 ```
 
-For a `Bash` decision the log records the command *shape* — the program plus its leading subcommand tokens (`git push`, `aws s3 cp`), stopping at the first flag, path, or value — rather than the full command, which keeps inline secrets (credentials in flags, URLs, or `VAR=value` prefixes) out of the plaintext log. The shape is what `/ClaudeWatch:learn` groups by, so nothing is lost for the workflow. The log file and its directory are owner-only (`0600`/`0700`).
+For a `Bash` decision the log records the command *shape* — the program plus its leading subcommand tokens (`git push`, `aws s3 cp`), stopping at the first flag, path, or value — rather than the full command, which keeps inline secrets (credentials in flags, URLs, or `VAR=value` prefixes) out of the plaintext log. The shape is what `/ClaudeWatch:learn` groups by, so nothing is lost for the workflow. The log file and its directory are owner-only (`0600`/`0700`) on macOS and Linux; on Windows this guarantee is degraded (see Platforms).
 
 Then `/ClaudeWatch:learn` aggregates the log into a batch proposal: frequently-allowed commands that aren't in your allowlist yet (promote them), ask rules you keep approving (add an `except`), and blocks that may be in your way. `scripts/analyze-decisions.py` does the read-only analysis; the skill drives the per-item approval. Because it works from the hook's own decisions rather than scanning transcripts heuristically, it distinguishes allowed / asked / blocked instead of guessing what looks read-only. You vet a window's worth of prompts once instead of one at a time. The proposal leads with the window it covers (records, sessions, span) so you can weigh it, and once you've applied changes the skill offers to reset the log (`scripts/reset-decisions.py`, archives by default) so the next pass measures from the new baseline rather than re-surfacing what you just handled.
 
@@ -88,6 +88,10 @@ Coverage is preserved: ClaudeWatch's `Write` and `Edit` hooks run the same `targ
 claude plugin marketplace add chris-peterson/claude-marketplace
 claude plugin install ClaudeWatch@chris-peterson
 ```
+
+### Platforms
+
+Supported on macOS, Linux, and Windows, including native Windows (PowerShell/cmd). The `PreToolUse` hooks run through a launcher that resolves a Python interpreter by probing `python3`, `python`, then the `py` launcher, so a vanilla install needs no PATH surgery. Both a bash launcher (`hooks/run-watchdog.sh`, used by `sh` on Unix and Git Bash on Windows) and a PowerShell launcher (`hooks/run-watchdog.ps1`, the native-Windows-without-Git-Bash path) ship; a `windows-latest` CI job exercises each. The decision log's owner-only file permission is enforced on macOS and Linux but degraded on Windows, where `chmod` honors only the read-only bit. See the Platforms section in [`SPEC.md`](SPEC.md) for the full contract.
 
 ## Updating
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -20,6 +20,7 @@ Requirement IDs use `[XX-NN]`. Categories:
 - **OUT** — Output decisions
 - **LOG** — Decision logging (on by default, opt-out side channel)
 - **HK** — Hook wiring
+- **PL** — Platforms (supported OSes, interpreter resolution)
 - **EXT** — Extensibility
 - **SK** — Skills (`/ClaudeWatch:help`, `/ClaudeWatch:rules`, `/ClaudeWatch:learn`)
 - **DOC** — Documentation
@@ -69,7 +70,7 @@ whether or not logging is enabled.
 - **[LOG-02]** Where `CLAUDEWATCH_LOG` is set to `off`, `0`, `false`, `none`, or the empty string (case-insensitive), the engine shall write no log, and its decision and exit behavior shall be unchanged. This is the opt-out.
 - **[LOG-03]** Each log record shall include the decision (`allow`/`ask`/`deny`), the matched rule reasons, a UTC timestamp, and the `session_id`, `cwd`, and active `permission_mode` from the hook input. For a `Bash` input the record shall include the *command shape* (field `command_shape`) — the program name plus its leading subcommand tokens, with any leading `VAR=value` assignments and `sudo` dropped and the token run stopping at the first flag, path, or value (e.g. `git push --force origin main` → `git push`, `SECRET=… mysql -p… db` → `mysql`) — rather than the raw command string. The shape is what `/ClaudeWatch:learn` groups by ([SK-14]); recording it rather than the full command keeps inline secrets (credentials in flags, URLs, or assignments) out of the durable, plaintext log. For a `Write`/`Edit` input the record shall include the target file path rather than the file content.
 - **[LOG-04]** Logging shall not influence the decision and shall not change the process exit code. If a log write fails, then the engine shall report the failure to stderr and otherwise continue, still emitting its decision.
-- **[LOG-05]** The engine shall restrict the decision log to owner-only access — file mode `0600` and its parent directory mode `0700` — applied on each write so a pre-existing wider mode is corrected, so that the plaintext log is not readable by other accounts on the host. A failure to set the mode shall be handled as a log-write failure per [LOG-04].
+- **[LOG-05]** The engine shall restrict the decision log to owner-only access — file mode `0600` and its parent directory mode `0700` — applied on each write so a pre-existing wider mode is corrected, so that the plaintext log is not readable by other accounts on the host. A failure to set the mode shall be handled as a log-write failure per [LOG-04]. On Windows, `os.chmod` honors only the read-only bit, so the POSIX owner-only guarantee is not enforced there; the log is written but its access is governed by the inherited NTFS ACL rather than mode `0600`. This is a documented platform limitation ([PL-04]) — the engine applies the same `chmod` call on every platform and does not implement a Windows ACL equivalent on the decision path, since that would add OS branching to the otherwise generic engine.
 - **[LOG-06]** The log shall begin with a header line `{"schema": N}` declaring the log's schema version, distinct from the per-input records of [LOG-01]. The current version is `2` (records store the command shape per [LOG-03]); version `1` is the pre-shape format that recorded the raw command string. On write, where the existing log has no header or declares a version other than the current one, the engine shall discard the existing log and start a fresh one with the current header, so that a log written under an earlier schema — which may contain raw commands with inline secrets — is not carried forward across an upgrade. Consumers of the log (the analyzer [SK-13] and the reset tool [SK-19]) shall ignore the header line. The discard applies to the active log only; archived logs ([SK-19]) are user-retained and left untouched.
 
 ## 2. Rule Sets (RS)
@@ -123,6 +124,22 @@ The engine emits at most one decision per invocation.
 - **[HK-02]** The plugin shall register a `SessionStart` hook for plugin-update self-checks. (Currently a no-op placeholder — see [FUT-01].)
 - **[HK-03]** The plugin shall declare its hooks in `hooks/hooks.json`.
 - **[HK-04]** The plugin shall register a `SessionStart` hook that emits ambient guidance into the session context advising that a consequential command be run as its own Bash call rather than piped or chained, so the compound-command escalation ([OUT-08]) is avoided before it triggers. The guidance shall be sourced from `rules/*.md` so it can be edited without changing the hook.
+- **[HK-05]** Each hook command shall be invoked through a portable launcher script under `hooks/` rather than naming an interpreter directly on the hook command line, so that interpreter resolution ([PL-02]) is a property of the launcher and a hook entry never bakes in a platform-specific interpreter name. The `PreToolUse` hooks shall launch the engine via the launcher; the `SessionStart` hooks shall be the shell scripts under `hooks/` directly.
+- **[HK-06]** A launcher shall be provided for each shell Claude Code may dispatch a command hook through ([PL-01a]): `hooks/run-watchdog.sh` for the POSIX-shell path (`sh -c` on macOS/Linux, Git Bash on Windows) and `hooks/run-watchdog.ps1` for the PowerShell path (native Windows with no Git Bash). Both perform the same interpreter resolution ([PL-02]) and the same fail-loud behavior ([PL-03]).
+
+## 5a. Platforms (PL)
+
+ClaudeWatch's engine is portable Python; the platform surface lives entirely in
+the *wiring* (the hook launchers), keeping the engine generic and stdlib-only
+on the decision path. These requirements state which platforms are supported
+and how an interpreter is resolved on each.
+
+- **[PL-01]** The plugin shall support macOS, Linux, and Windows as host platforms for Claude Code, including **genuine native Windows** (PowerShell/cmd, not only WSL or Git Bash). Under WSL the host is Linux and is already covered by the Linux path; the native-Windows requirement is the one that closes the gap.
+- **[PL-01a]** *(Open — resolved by CI.)* Claude Code dispatches a shell-form command hook through `sh -c` on macOS/Linux, **Git Bash on Windows, or PowerShell when Git Bash isn't installed** (per the Claude Code hooks reference). Whether a vanilla native-Windows Claude Code install routes the plugin's hook through Git Bash or PowerShell cannot be verified from a non-Windows development host. Rather than assert it, the plugin ships a launcher for **both** paths ([HK-06]) and the CI suite exercises each on a `windows-latest` runner (`.github/workflows/ci.yml`); the runner is the evidence for which path resolves an interpreter and produces a decision. When the dispatch behavior is confirmed, this requirement records the answer and the unused launcher path can be reconsidered.
+- **[PL-02]** Each hook launcher shall resolve a Python interpreter at run time by probing, in order, `python3`, then `python`, then the `py` launcher, and shall invoke the first one found. On a standard native-Windows Python install `py` (the `py.exe` launcher) and `python` are reliably present while `python3` is not; on macOS/Linux `python3` is the convention. If none resolves, the launcher shall fail loudly to stderr with a message naming the interpreters it tried, rather than silently producing no decision. (A `PreToolUse` hook that fails to launch produces no decision, which the host reads as allow-by-default — so the absence of an interpreter must be a visible error, not a silent no-op.)
+- **[PL-03]** A launcher shall not embed a fallback decision. When the interpreter cannot be resolved or the engine cannot run, the launcher surfaces the failure on stderr and exits without emitting a decision; it shall not fabricate an `allow`, `ask`, or `deny` in place of the engine's output.
+- **[PL-04]** The decision log's owner-only access guarantee ([LOG-05]) is enforced via POSIX file modes and therefore holds on macOS and Linux. On Windows the guarantee is **degraded**: `chmod` honors only the read-only bit and the file's access is governed by the inherited NTFS ACL. This limitation is documented rather than worked around on the decision path; a Windows ACL equivalent is out of scope for the initial port.
+- **[PL-05]** The shipped rule patterns ([SH-01]) match the command or file-content string regardless of host OS. Several target Unix-native destructive primitives (`rm -rf /`, `dd of=/dev/sd*`, `mkfs`, `~/.ssh`, `~/.aws/credentials`); these are correct on Windows but rarely fire for a user working in PowerShell or cmd. `watch-pwsh` is the set aimed at the Windows command surface. Adding Windows-native destructive patterns is additive and out of scope here.
 
 ## 6. Extensibility (EXT)
 
@@ -228,9 +245,25 @@ These describe how the current implementation satisfies the spec. They are
 - The engine is a single Python script at `scripts/watchdog.py` with a minimal
   pure-Python YAML parser (no PyYAML dependency). The parser supports inline
   list syntax (`['.ps1', '.psm1']`) for the top-level `extensions` field.
-- The hook command line is
-  `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/watchdog.py ${CLAUDE_PLUGIN_ROOT}/watches`,
-  invoked from two `PreToolUse` matchers: `Bash` and `Write|Edit`.
+- The two `PreToolUse` matchers (`Bash` and `Write|Edit`) both invoke
+  `bash ${CLAUDE_PLUGIN_ROOT}/hooks/run-watchdog.sh` in shell form (no `shell`
+  field, so the host applies its default per-platform shell selection: `sh -c`
+  on macOS/Linux, Git Bash on Windows, PowerShell when Git Bash isn't
+  installed). `run-watchdog.sh` probes `python3` → `python` → `py` ([PL-02]) and
+  `exec`s the first found against
+  `${CLAUDE_PLUGIN_ROOT}/scripts/watchdog.py ${CLAUDE_PLUGIN_ROOT}/watches`;
+  `run-watchdog.ps1` is the PowerShell-path counterpart, probing the same order
+  and piping stdin through to the engine. Both fail loudly with no fabricated
+  decision when no interpreter resolves ([PL-03]). The interpreter probe lives
+  in the launchers, not in `hooks.json`, so a hook entry never names a
+  platform-specific interpreter.
+- Native-Windows hook dispatch (Git Bash vs PowerShell) cannot be verified from
+  a macOS/Linux dev host, so `.github/workflows/ci.yml` runs the suite on
+  `ubuntu-latest` and, on a `windows-latest` runner, exercises both launchers
+  (`.sh` via the runner's Git Bash, `.ps1` via PowerShell) plus the engine
+  directly under `python`/`py` — confirming interpreter resolution, a
+  `PreToolUse` decision, the loud-failure path, and the `SessionStart` scripts'
+  emission. The Windows CI run is the evidence for [PL-01a].
 - The SessionStart hook (`hooks/cli-freshness.sh`) is intentionally a no-op
   placeholder for future plugin-update self-checks; ClaudeWatch does not
   install a CLI shim, so the freshness-check pattern used by sibling plugins

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/watchdog.py ${CLAUDE_PLUGIN_ROOT}/watches"
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/run-watchdog.sh"
           }
         ]
       },
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/watchdog.py ${CLAUDE_PLUGIN_ROOT}/watches"
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/run-watchdog.sh"
           }
         ]
       }

--- a/hooks/run-watchdog.ps1
+++ b/hooks/run-watchdog.ps1
@@ -1,0 +1,30 @@
+# PreToolUse launcher (PowerShell): the native-Windows path for hosts where
+# Claude Code dispatches command hooks through PowerShell rather than Git Bash.
+# Mirrors run-watchdog.sh — resolve a Python interpreter at run time and run the
+# engine, with no fabricated decision on failure (see [HK-05], [PL-02], [PL-03]
+# in SPEC.md).
+#
+# On a standard Windows Python install the `py` launcher (py.exe) and `python`
+# are reliably on PATH; `python3` is not. Probe python3 -> python -> py and use
+# the first one found. Resolution failure is loud (non-zero exit, stderr
+# message) rather than a silent no-op, because a PreToolUse hook that produces
+# no decision is read by the host as allow-by-default.
+
+$ErrorActionPreference = 'Stop'
+
+$engine  = Join-Path $env:CLAUDE_PLUGIN_ROOT 'scripts/watchdog.py'
+$watches = Join-Path $env:CLAUDE_PLUGIN_ROOT 'watches'
+
+# stdin (the tool-input JSON) is read once and forwarded to the interpreter.
+$stdin = [Console]::In.ReadToEnd()
+
+foreach ($interp in @('python3', 'python', 'py')) {
+    $resolved = Get-Command $interp -ErrorAction SilentlyContinue
+    if ($resolved) {
+        $stdin | & $resolved.Source $engine $watches
+        exit $LASTEXITCODE
+    }
+}
+
+[Console]::Error.WriteLine('ClaudeWatch: no Python interpreter found (tried python3, python, py); the safety hook cannot run.')
+exit 1

--- a/hooks/run-watchdog.sh
+++ b/hooks/run-watchdog.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# PreToolUse launcher: run the watchdog engine under whichever Python interpreter
+# the host provides. The hook entry invokes this script rather than naming an
+# interpreter directly, so interpreter resolution is a property of the launcher
+# and the same hooks.json works on macOS, Linux, and Windows (Git Bash) — see
+# [HK-05], [PL-02] in SPEC.md.
+#
+# On a standard Windows Python install the executable is `python.exe` plus the
+# `py` launcher; `python3` is not reliably on PATH. On macOS/Linux `python3` is
+# the convention. Probe in that order and exec the first one found.
+#
+# Resolution failure is a visible error, never a silent no-op: a PreToolUse hook
+# that fails to launch produces no decision, which the host reads as
+# allow-by-default. There is no fallback decision ([PL-03]) — if no interpreter
+# resolves, fail loudly to stderr and exit non-zero.
+
+set -euo pipefail
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+ENGINE="$PLUGIN_ROOT/scripts/watchdog.py"
+WATCHES="$PLUGIN_ROOT/watches"
+
+for interp in python3 python py; do
+  if command -v "$interp" >/dev/null 2>&1; then
+    exec "$interp" "$ENGINE" "$WATCHES"
+  fi
+done
+
+echo "ClaudeWatch: no Python interpreter found (tried python3, python, py); the safety hook cannot run." >&2
+exit 1

--- a/scripts/watchdog.py
+++ b/scripts/watchdog.py
@@ -484,6 +484,9 @@ def _log_event(data, input_kind, input_text, decision, matched):
             f.write(json.dumps(entry, separators=(",", ":")) + "\n")
         # Owner-only access ([LOG-05]). Applied every write so a pre-existing
         # wider mode (e.g. a 0644 log from before this was enforced) is corrected.
+        # On Windows chmod honors only the read-only bit, so the owner-only
+        # guarantee is degraded there ([PL-04]); the same call runs on every
+        # platform to keep the engine free of OS branching.
         os.chmod(dest, 0o600)
         if parent:
             os.chmod(parent, 0o700)

--- a/tests/test-launcher.sh
+++ b/tests/test-launcher.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Tests for the PreToolUse interpreter launcher (hooks/run-watchdog.sh,
+# [HK-05], [PL-02], [PL-03]). The launcher resolves a Python interpreter at run
+# time and execs the engine; on resolution failure it fails loudly with no
+# fabricated decision.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LAUNCHER="$PLUGIN_ROOT/hooks/run-watchdog.sh"
+
+PASS=0
+FAIL=0
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() { PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+echo "Running launcher tests..."
+
+# 1. End-to-end: a known block command run through the launcher produces a deny.
+#    This exercises interpreter resolution + exec of the engine, not just the
+#    engine in isolation.
+block_input='{"tool_name":"Bash","tool_input":{"command":"git push --force origin main"}}'
+out=$(printf '%s' "$block_input" | CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" CLAUDEWATCH_LOG=off bash "$LAUNCHER" 2>/dev/null || true)
+if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+  pass "launcher resolves an interpreter and runs the engine (deny on block command)"
+else
+  fail "launcher should emit deny for a block command (got: ${out:-empty})"
+fi
+
+# 2. A non-matching command produces no output (allow-by-silence), proving the
+#    launcher forwards the engine's allow path rather than fabricating output.
+allow_input='{"tool_name":"Bash","tool_input":{"command":"git status"}}'
+out=$(printf '%s' "$allow_input" | CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" CLAUDEWATCH_LOG=off bash "$LAUNCHER" 2>/dev/null || true)
+if [ -z "$out" ]; then
+  pass "launcher forwards the engine's allow-by-silence (no output)"
+else
+  fail "launcher should produce no output for an allowed command (got: $out)"
+fi
+
+# 3. Resolution failure is loud and produces no decision ([PL-02], [PL-03]).
+#    Point PATH at a directory that holds no interpreter so the launcher's
+#    `command -v` finds none. A nonexistent directory (rather than the empty
+#    string) is used on purpose: bash falls back to a compiled-in default PATH
+#    when PATH is empty or unset, which would let an interpreter resolve and
+#    defeat the test. The launcher's own bash is invoked by absolute path so the
+#    restricted PATH blocks only the interpreter probe, not the launcher itself.
+no_python_path="/nonexistent-claudewatch-launcher-test"
+bash_bin="$(command -v bash)"
+stdout_file="$(mktemp "${TMPDIR:-/tmp}/claudewatch-launcher-stdout.XXXXXX")"
+stderr_file="$(mktemp "${TMPDIR:-/tmp}/claudewatch-launcher-stderr.XXXXXX")"
+set +e
+printf '%s' "$block_input" | CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" CLAUDEWATCH_LOG=off PATH="$no_python_path" "$bash_bin" "$LAUNCHER" >"$stdout_file" 2>"$stderr_file"
+rc=$?
+set -e
+out_on_fail="$(<"$stdout_file")"
+err_on_fail="$(<"$stderr_file")"
+rm -f "$stdout_file" "$stderr_file"
+
+if [ "$rc" -ne 0 ]; then
+  pass "launcher exits non-zero when no interpreter resolves"
+else
+  fail "launcher should exit non-zero when no interpreter resolves (got rc=$rc)"
+fi
+
+if [ -z "$out_on_fail" ]; then
+  pass "launcher emits no decision on resolution failure (no fallback)"
+else
+  fail "launcher must not fabricate a decision on failure (got: $out_on_fail)"
+fi
+
+if printf '%s' "$err_on_fail" | grep -q "no Python interpreter found"; then
+  pass "launcher reports the resolution failure on stderr"
+else
+  fail "launcher should report the failure on stderr (got: ${err_on_fail:-empty})"
+fi
+
+# 4. PowerShell launcher (hooks/run-watchdog.ps1) — the native-Windows path.
+#    Exercised wherever pwsh is available (any platform); skipped cleanly when
+#    it isn't, so the suite stays green on a host without PowerShell. The
+#    native-Windows shell-dispatch question is settled by the windows-latest CI
+#    job; this case proves the .ps1 launcher's resolution and fail-loud logic
+#    against a real PowerShell.
+PS_LAUNCHER="$PLUGIN_ROOT/hooks/run-watchdog.ps1"
+if command -v pwsh >/dev/null 2>&1; then
+  ps_out=$(printf '%s' "$block_input" | CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" CLAUDEWATCH_LOG=off pwsh -NoProfile -File "$PS_LAUNCHER" 2>/dev/null || true)
+  if printf '%s' "$ps_out" | grep -q '"permissionDecision":"deny"'; then
+    pass "ps1 launcher resolves an interpreter and runs the engine (deny on block command)"
+  else
+    fail "ps1 launcher should emit deny for a block command (got: ${ps_out:-empty})"
+  fi
+
+  pwsh_bin="$(command -v pwsh)"
+  ps_stdout_file="$(mktemp "${TMPDIR:-/tmp}/claudewatch-ps-stdout.XXXXXX")"
+  ps_stderr_file="$(mktemp "${TMPDIR:-/tmp}/claudewatch-ps-stderr.XXXXXX")"
+  set +e
+  printf '%s' "$block_input" | CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" CLAUDEWATCH_LOG=off PATH="$no_python_path" "$pwsh_bin" -NoProfile -File "$PS_LAUNCHER" >"$ps_stdout_file" 2>"$ps_stderr_file"
+  ps_rc=$?
+  set -e
+  ps_out_on_fail="$(<"$ps_stdout_file")"
+  ps_err_on_fail="$(<"$ps_stderr_file")"
+  rm -f "$ps_stdout_file" "$ps_stderr_file"
+
+  if [ "$ps_rc" -ne 0 ] && [ -z "$ps_out_on_fail" ] && printf '%s' "$ps_err_on_fail" | grep -q "no Python interpreter found"; then
+    pass "ps1 launcher fails loud with no fabricated decision when no interpreter resolves"
+  else
+    fail "ps1 launcher should fail loud and emit no decision (rc=$ps_rc, out=${ps_out_on_fail:-empty}, err=${ps_err_on_fail:-empty})"
+  fi
+else
+  echo "  SKIP: PowerShell (pwsh) not available; ps1 launcher cases skipped"
+fi
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/tests/test-watchdog.sh
+++ b/tests/test-watchdog.sh
@@ -12,7 +12,7 @@ echo "========================================"
 echo "  claude-watchdog tests"
 echo "========================================"
 
-for test_file in "$SCRIPT_DIR"/test-watch-*.sh "$SCRIPT_DIR"/test-engine.sh "$SCRIPT_DIR"/test-output.sh "$SCRIPT_DIR"/test-logging.sh "$SCRIPT_DIR"/test-analyze.sh "$SCRIPT_DIR"/test-reset-decisions.sh "$SCRIPT_DIR"/test-ambient.sh; do
+for test_file in "$SCRIPT_DIR"/test-watch-*.sh "$SCRIPT_DIR"/test-engine.sh "$SCRIPT_DIR"/test-output.sh "$SCRIPT_DIR"/test-logging.sh "$SCRIPT_DIR"/test-analyze.sh "$SCRIPT_DIR"/test-reset-decisions.sh "$SCRIPT_DIR"/test-ambient.sh "$SCRIPT_DIR"/test-launcher.sh; do
   echo ""
   if bash "$test_file"; then
     :


### PR DESCRIPTION
## Why

A Windows Claude Code user who installs ClaudeWatch gets no safety net, silently. The `PreToolUse` hooks named interpreters directly on the command line — `python3 .../watchdog.py` and `bash .../*.sh`. On a standard Windows Python install the executable is `python` plus the `py` launcher (`python3` is not reliably on PATH), and native Windows has no `bash`. When the interpreter doesn't resolve, the hook fails to launch and produces no decision, which the host reads as allow-by-default. The guardrails Unix users rely on are absent with no error.

This is the work scoped in #15. Per `AGENTS.md`, platform assumptions are deliberate, so the change starts in `SPEC.md` and keeps the cross-platform logic in the wiring (launchers) rather than the engine — the engine stays generic and stdlib-only on the decision path.

## What changed

**Portable launchers (interpreter resolution moves out of the hook entry).**
- `hooks/run-watchdog.sh` (POSIX shell / Git Bash) and `hooks/run-watchdog.ps1` (PowerShell) each probe `python3` → `python` → `py` and run the engine against the `watches/` directory.
- Neither embeds a fallback decision. If no interpreter resolves, the launcher exits non-zero with a stderr message rather than emitting a fabricated `allow`/`ask`/`deny` — a silent no-op would read as allow-by-default, so the failure is made visible.
- `hooks/hooks.json` invokes `run-watchdog.sh` in shell form (no `shell` pin), so the host applies its documented per-platform shell selection: `sh -c` on macOS/Linux, Git Bash on Windows, PowerShell when Git Bash isn't installed.

**Spec and docs.**
- `SPEC.md` adds a Platforms section (`PL-01`..`PL-05`): native-Windows support (PowerShell/cmd, not only WSL/Git Bash), the interpreter-resolution and no-fallback contracts, the Unix-rule-relevance note, and the degraded log-permission guarantee on Windows. `LOG-05` records that the owner-only file mode honors only the read-only bit on Windows; the engine keeps its single permission call rather than branching on OS (`PL-04`).
- `AGENTS.md` and `README.md` state the supported platforms.

**The open dispatch question, settled by CI (acceptance criterion #1).**
Whether a vanilla native-Windows install routes the hook through Git Bash or PowerShell cannot be verified from a macOS/Linux host. Rather than assert it, both launcher paths ship and a new `.github/workflows/ci.yml` provides the evidence: it runs the suite on `ubuntu-latest` and, on a `windows-latest` runner, exercises the engine directly under Windows Python, both launchers (`.ps1` via PowerShell, `.sh` via Git Bash), the loud-failure path, and the SessionStart scripts. `PL-01a` records this as open with the CI run as the evidence; when the dispatch behavior is confirmed there, the requirement can record the answer and the unused launcher path reconsidered.

## Verification

- `bash tests/test-watchdog.sh` — full suite green on this macOS host.
- New `tests/test-launcher.sh` (wired into the suite) covers both launchers: interpreter resolution and a `PreToolUse` decision, allow-by-silence, and the loud-failure-with-no-fabricated-decision path. The PowerShell cases run wherever `pwsh` is present (verified here against `pwsh` on macOS) and skip cleanly otherwise.
- The native-Windows shell-dispatch behavior is **not** verified locally — that is what the `windows-latest` CI job is for. The first CI run on this PR is the evidence for `PL-01a`.

## Scope

Tier 3 of the issue (adding Windows-native destructive rule patterns) is additive and intentionally out of scope; `PL-05` notes it. No Windows ACL equivalent for the log is implemented — the degraded guarantee is documented per the issue's "decide whether in scope."

Closes #15
