### PR TITLE
implement session mute

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ See [`CHANGELOG.md`](CHANGELOG.md) for release notes.
 
 See the [docs site](https://chris-peterson.github.io/ClaudeWatch/) for usage, configuration, and the full [rules](https://chris-peterson.github.io/ClaudeWatch/#/rules) reference. The YAML rule format is documented for rule authors in [`SCHEMA.md`](SCHEMA.md).
 
-In-session, run `/ClaudeWatch:rules` to view and edit rules interactively, or `/ClaudeWatch:learn` to cut prompt fatigue from your decision log.
+In-session, run `/ClaudeWatch:rules` to view and edit rules interactively, or `/ClaudeWatch:learn` to cut prompt fatigue from your decision log. When a chatty recipe keeps prompting on recoverable ops, `/ClaudeWatch:mute git` (or a single rule, `/ClaudeWatch:mute "git commit"`) silences those *ask* prompts for the rest of the session — block rules still fire, so you can let the agent run and review at the end. `/ClaudeWatch:unmute` and `/ClaudeWatch:mutes` clear and list them; mutes self-clear when the session ends.
 
 ## Development
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -10,7 +10,7 @@ and at the moment a script file is authored.
 
 This spec captures the contract — what the system must do — independent of
 how it's currently implemented. Mechanism notes (current file layout, parser
-internals) live in §11.
+internals) live in §13.
 
 Requirement IDs use `[XX-NN]`. Categories:
 
@@ -22,6 +22,7 @@ Requirement IDs use `[XX-NN]`. Categories:
 - **HK** — Hook wiring
 - **EXT** — Extensibility
 - **SK** — Skills (`/ClaudeWatch:rules`, `/ClaudeWatch:learn`)
+- **MUTE** — Session mutes (per-session `ask` suppression)
 - **DOC** — Documentation
 - **DIST** — Distribution / install
 - **SH** — Shipped rule sets
@@ -37,7 +38,10 @@ Unwanted (`If…then`).
 ## 1. Engine (EN)
 
 **Core contract:** Given tool input on stdin, the engine deterministically
-emits exactly one of `{deny, ask, no-output}` and exits 0. The engine handles
+emits exactly one of `{deny, ask, no-output}` and exits 0. The decision is a
+pure function of the tool input, the working directory (`cwd`), the `watches/`
+rule tree, and — where present — the active session's mute set ([MUTE-03]); no
+clock, randomness, or network enters the decision path. The engine handles
 three tool inputs: `Bash` (matched against the bash command string), `Write`
 (matched against the new file content), and `Edit` (matched against the full
 post-edit file content).
@@ -125,6 +129,8 @@ The engine emits at most one decision per invocation.
 - **[HK-02]** The plugin shall register a `SessionStart` hook for plugin-update self-checks. (Currently a no-op placeholder — see [FUT-01].)
 - **[HK-03]** The plugin shall declare its hooks in `hooks/hooks.json`.
 - **[HK-04]** The plugin shall register a `SessionStart` hook that emits ambient guidance into the session context advising that a consequential command be run as its own Bash call rather than piped or chained, so the compound-command escalation ([OUT-08]) is avoided before it triggers. The guidance shall be sourced from `rules/*.md` so it can be edited without changing the hook.
+- **[HK-05]** The plugin shall register a `SessionEnd` hook that deletes the ending session's mute file and its `cwd → session_id` pointer ([HK-06], [MUTE-04]), so a session mute ([MUTE-01]) never outlives its session. `SessionEnd` is non-blocking; the hook's output is advisory and it shall exit 0.
+- **[HK-06]** The plugin shall register a `SessionStart` hook that records a `cwd → session_id` pointer in the mute store ([MUTE-04]), so the mute skill — which does not receive `session_id` (Claude Code supplies it on hook stdin but not as an environment variable to slash commands or bash) — can resolve the active session from its own `cwd`. Where two sessions share a `cwd`, the pointer is last-writer-wins; because the engine's read path ([MUTE-03]) keys on the exact `session_id` from stdin, a collision can misdirect a *write* but never misapply a mute to a session it was not written for.
 
 ## 6. Extensibility (EXT)
 
@@ -167,20 +173,40 @@ rather than per command.
 - **[SK-18]** The analysis shall report the window its proposals are drawn from: the number of decision records considered, the count of distinct sessions among them, and the time span from the oldest to the newest record. The skill shall surface this so the user can weigh how much history backs the suggestions.
 - **[SK-19]** The skill shall offer to reset the decision log after the user has applied their chosen changes, so that the next analysis measures from the post-change baseline rather than re-surfacing already-dispositioned commands. Reset shall **archive** the current log by default — moving it to a fixed user directory (`~/.claude/claudewatch/archive/`, beside the durable log per [LOG-01]) so the prior history is recoverable — and shall support a `--hard` mode that deletes it outright. Where logging is disabled ([LOG-02]) or no log exists, reset shall make no change and shall report why. Reset shall report what it cleared (record count and span).
 
-## 8. Documentation (DOC)
+## 8. Session Mute (MUTE)
+
+A *session mute* silences a rule set's or an individual rule's `ask` prompts
+for the duration of one Claude Code session — for a commit-heavy recipe where
+`watch-git`'s `git commit`/`--amend` asks fire repeatedly and the user intends
+to review the accumulated work at the end rather than approve each step. It is
+the *session-scoped, ephemeral* counterpart to the *repo-scoped, persistent*
+trust of [FUT-05]: both suppress `ask` decisions only and neither ever waives a
+`block` rule, but they key on different things (session identity vs. target
+repo) and have different lifetimes.
+
+- **[MUTE-01]** A session mute shall suppress `ask` rules only. When a `block` rule matches, the engine shall emit its `deny` regardless of any active mute, mirroring the `except`/`unless_*` law ([RL-08], [RL-15]) that block is un-bypassable. This is the property that makes "let the agent run wild, review at the end" safe: muting `watch-git` silences the recoverable `commit`/`amend`/`reset --hard` prompts while `push --force` and its fellow block rules still fire.
+- **[MUTE-02]** A mute name shall resolve against both rule-set names (e.g. `git` or `watch-git`, muting all that set's `ask` rules) and individual rule names (e.g. `git-commit`, muting that one rule). While a session has an active mute, the engine shall skip — emit no ask for — every matched `ask` rule whose rule `name` or containing rule-set `name` is in that session's mute set, evaluated at the same point as the [RL-07]/[RL-15] exemptions.
+- **[MUTE-03]** The engine shall read the active session's mute set on the decision path keyed by the `session_id` on the hook input ([LOG-03]). Reading the mute set shall be a pure file read with no clock, randomness, or network, so the decision stays deterministic (core contract #1, [EN]): the mute set is a deterministic file input like the `watches/` tree, and `session_id` a deterministic stdin input like `cwd` ([RL-16]). Because expiry cannot be evaluated without a clock on the decision path, a mute shall be scoped to session lifetime — established by the SessionStart/SessionEnd hooks ([HK-05], [HK-06]) — rather than a wall-clock TTL.
+- **[MUTE-04]** The mute set shall be stored per session in the durable user directory `~/.claude/claudewatch/mutes/`, beside the decision log ([LOG-01]) and outside the version-scoped plugin cache, so the fixed path resolves identically for the engine, the mute skill, and the session hooks regardless of installed plugin version (the durability rationale of [FUT-04]). The engine and skill shall restrict the store to owner-only access as the decision log is restricted ([LOG-05]).
+- **[MUTE-05]** The plugin shall ship a skill exposing `/ClaudeWatch:mute <name>`, `/ClaudeWatch:unmute <name>`, and a bare `/ClaudeWatch:mutes` (list the session's active mutes). A natural-language request ("stop asking me about commits this session") shall route to the same skill. The skill shall write and read the [MUTE-04] store for the active session, resolved via the [HK-06] pointer.
+- **[MUTE-06]** When the skill applies a mute, it shall confirm explicitly which `ask` rules it disabled for the session — naming each — and how to clear it (`/ClaudeWatch:unmute <name>`), so the user always knows the current suppression state and its undo.
+- **[MUTE-07]** If a mute name resolves to no `ask` rules — a name matching only block rules, or matching nothing — then the skill shall make no change and shall report why ("`<name>` has no ask rules; nothing to mute" / "no rule or rule set named `<name>`"), rather than silently recording an inert mute.
+- **[MUTE-08]** In the `permissionDecisionReason` of an `ask` decision — but not in the logged reasons ([LOG-03]) — the engine should include a display-only hint naming the mute command for the matched rule (e.g. `mute for this session: /ClaudeWatch:mute git-commit`), so the affordance is taught at the point of friction. Like the OSC 8 hyperlink of [OUT-06], the hint is presentation-only.
+
+## 9. Documentation (DOC)
 
 - **[DOC-01]** The plugin shall ship a Docsify documentation site under `docs/`.
 - **[DOC-02]** `just docs` shall regenerate the rules-reference page from the YAML rule files.
 - **[DOC-04]** The documentation shall include a YAML schema reference covering top-level fields and rule fields.
 - **[DOC-05]** `just docs` shall regenerate a prompts page, linked from the docs-site sidebar, approximating the Claude Code permission prompt each rule produces — block rules as an outright rejection, ask rules as a confirmation prompt — with the reason prose linking to the rule's `ref`.
 
-## 9. Distribution (DIST)
+## 10. Distribution (DIST)
 
 - **[DIST-01]** The plugin shall expose the metadata required for installation as a Claude Code plugin (name, version, description, repository, license) in its manifest. The mechanism by which the plugin is hosted or distributed (marketplace registration, install command) is out of scope.
 - **[DIST-02]** The plugin shall declare a manifest at `.claude-plugin/plugin.json`.
 - **[DIST-03]** The plugin shall be runnable from a working copy via `claude --plugin-dir .` (no install required for local testing).
 
-## 10. Shipped Rule Sets (SH)
+## 11. Shipped Rule Sets (SH)
 
 These are the rule sets the plugin ships out of the box. Each is
 self-contained and removable by renaming its file to `*.yml.disabled`.
@@ -213,14 +239,14 @@ self-contained and removable by renaming its file to `*.yml.disabled`.
 - **[SH-03]** Each shipped rule set shall include `ref` URLs pointing to upstream tool documentation, vendor docs, or a CWE/OWASP entry.
 - **[SH-04]** Each shipped rule set shall have a corresponding test file `tests/test-watch-<name>.sh` that exercises representative match/no-match cases.
 
-## 11. Development & Testing (DEV)
+## 12. Development & Testing (DEV)
 
 - **[DEV-01]** `just test` shall run the full test suite via `tests/test-watchdog.sh`.
 - **[DEV-02]** The test suite shall exercise each shipped rule set independently and shall also exercise engine-level behavior (decision aggregation, error handling, file/directory rules paths).
 - **[DEV-03]** `just rules` shall launch an interactive Claude Code session with the local plugin loaded and the rules skill open.
 - **[DEV-04]** `just docs-preview` shall serve the generated docs locally for review.
 
-## 12. Implementation Notes (non-normative)
+## 13. Implementation Notes (non-normative)
 
 These describe how the current implementation satisfies the spec. They are
 *not* requirements — they may change without bumping the spec version.
@@ -263,11 +289,11 @@ These describe how the current implementation satisfies the spec. They are
   stripping does not affect which rules fire — only whether a matched `ask` is
   escalated.
 
-## 13. Future / Deferred (FUT)
+## 14. Future / Deferred (FUT)
 
 - **[FUT-01]** Where a plugin-update self-check is implemented, the SessionStart hook shall verify `watchdog.py` emits the expected `hookSpecificOutput.permissionDecision` schema.
-- **[FUT-02]** Where the user adds a custom rule set via `/ClaudeWatch:rules new`, the skill should offer to scaffold a matching test file in `tests/`.
+- **[FUT-02]** Where the user adds a custom rule set via `/ClaudeWatch:rules new` ([SK-11]), the skill should scaffold a matching test file `tests/test-watch-<name>.sh` in the [SH-04] shape. The rules skill already offers to add test *coverage* after a write, but for a brand-new set there is no test file to write into, so the set ships untested until the author hand-creates it; scaffolding the file on `new` closes that gap.
 - **[FUT-03]** Where multi-line YAML strings or nested anchors are required, the parser may switch to PyYAML; currently the minimal parser does not support these constructs.
-- **[FUT-04]** Where the user customizes rules on an installed plugin via `/ClaudeWatch:rules` (including the `except` and demotion edits proposed by `/ClaudeWatch:learn`, which route through that skill), those edits shall survive plugin version upgrades. The skill writes to `${CLAUDE_PLUGIN_ROOT}/watches`, which for an installed plugin resolves to the version-scoped cache directory (e.g. `~/.claude/plugins/cache/chris-peterson/ClaudeWatch/0.8.0/watches/`); an upgrade installs a fresh version directory with its own shipped rules and the hook reads from the new root, orphaning prior edits. The decision log ([LOG-01]) already shows the durable shape: it lives in a fixed user directory (`~/.claude/claudewatch/`) outside the cache and so persists across upgrades. The gap closes by giving rule customizations the same treatment — a user rules directory alongside it (`~/.claude/claudewatch/watches/`) that the engine loads in addition to the shipped set (user rules winning on conflict), or a migration step on upgrade. Until then, only allow-list outputs of `/ClaudeWatch:learn` (written to `settings.json`) are durable on an installed plugin; rule edits are not. Edits made when running from a working copy via `claude --plugin-dir .` (per [DIST-03]) are already durable because `${CLAUDE_PLUGIN_ROOT}` is the git-tracked checkout, not the cache.
-- **[FUT-05]** Where the user designates specific repositories as trusted for otherwise-prompted git operations (e.g. a personal knowledge repo or a dashboard repo where unattended `commit`/`push` is acceptable), the engine should suppress `watch-git`'s `ask` decisions for commands targeting those repos while still applying them everywhere else. This is *repo-scoped* allow configuration, distinct from the command-shape allow-list in `settings.json` (which blanket-allows a command in every directory) and from `except` (which exempts a command *variant*, not a *location*). The trusted set keys on the resolved target repo — the `git -C <path>` argument when present, otherwise the invocation's working directory — matched by path prefix or by remote URL. Determinism (core contract #1) holds because the target repo is a pure function of the hook input (the command string plus the cwd Claude Code already passes), with no clock or network on the decision path. The configuration must survive plugin upgrades, so it lives in the durable user directory described in [FUT-04] (`~/.claude/claudewatch/`), not in the version-scoped cache. Open questions: whether the match key is filesystem path, remote URL, or both (a path moves; a remote is stable but absent for never-pushed repos); whether trust is scoped per rule set (`watch-git` only) or is a general repo-scoped allow applying to any rule; and whether `push --force`-class **block** rules are ever in scope (likely not — "no recovery" should not be repo-waivable).
-- **[FUT-06]** Where persistent standalone install (without the central chris-peterson marketplace) becomes a goal, the repo may ship its own single-plugin `.claude-plugin/marketplace.json` (`source: "./"`) so users can `/plugin marketplace add <this-repo>` and `/plugin install`. Claude Code has no bare git-URL install; a marketplace descriptor is the only path to a *persistent* install, and [DIST-01] currently holds distribution out of scope. This must be a **generated artifact** from `plugin.yml`'s existing `marketplace:` block (the same single source of truth as `plugin.json`), never hand-authored. Deferred: `claude --plugin-dir .` ([DIST-03]) already covers clone-and-run standalone use, so the marginal gain is low until a persistent install is actually wanted.
+- **[FUT-04]** Where the user customizes rules on an installed plugin via `/ClaudeWatch:rules` (including the `except` and demotion edits proposed by `/ClaudeWatch:learn`, which route through that skill), those edits shall survive plugin version upgrades. The skill writes to `${CLAUDE_PLUGIN_ROOT}/watches`, which for an installed plugin resolves to the version-scoped cache directory (e.g. `~/.claude/plugins/cache/chris-peterson/ClaudeWatch/0.8.0/watches/`); an upgrade installs a fresh version directory with its own shipped rules and the hook reads from the new root, orphaning prior edits. The decision log ([LOG-01]) and the session-mute store ([MUTE-04]) already show the durable shape: they live in a fixed user directory (`~/.claude/claudewatch/`) outside the cache and so persist across upgrades. The gap closes by giving rule customizations the same treatment — a user rules directory alongside it (`~/.claude/claudewatch/watches/`) that the engine loads in addition to the shipped set (user rules winning on conflict), or a migration step on upgrade. Until then, only allow-list outputs of `/ClaudeWatch:learn` (written to `settings.json`) are durable on an installed plugin; rule edits are not. Edits made when running from a working copy via `claude --plugin-dir .` (per [DIST-03]) are already durable because `${CLAUDE_PLUGIN_ROOT}` is the git-tracked checkout, not the cache.
+- **[FUT-05]** Where the user designates specific repositories as trusted for otherwise-prompted git operations (e.g. a personal knowledge repo or a dashboard repo where unattended `commit`/`push` is acceptable), the engine should suppress `watch-git`'s `ask` decisions for commands targeting those repos while still applying them everywhere else. This is *repo-scoped* allow configuration, distinct from the command-shape allow-list in `settings.json` (which blanket-allows a command in every directory) and from `except` (which exempts a command *variant*, not a *location*). The trusted set keys on the resolved target repo — the `git -C <path>` argument when present, otherwise the invocation's working directory — matched by path prefix or by remote URL. Determinism (core contract #1) holds because the target repo is a pure function of the hook input (the command string plus the cwd Claude Code already passes), with no clock or network on the decision path. The configuration must survive plugin upgrades, so it lives in the durable user directory described in [FUT-04] (`~/.claude/claudewatch/`), not in the version-scoped cache. Open questions: whether the match key is filesystem path, remote URL, or both (a path moves; a remote is stable but absent for never-pushed repos); whether trust is scoped per rule set (`watch-git` only) or is a general repo-scoped allow applying to any rule; and whether `push --force`-class **block** rules are ever in scope (likely not — "no recovery" should not be repo-waivable). See §8 (Session Mute, [MUTE-01]) for the *session-scoped, ephemeral* sibling of this *repo-scoped, persistent* trust; both suppress `ask` decisions only and would likely share one durable suppression store ([MUTE-04]) and skip-point ([MUTE-02]).
+> **[FUT-06]** *(declined 2026-07-08)* — a standalone single-plugin `.claude-plugin/marketplace.json` (`source: "./"`) for `/plugin marketplace add`-based install was considered and declined. `claude --plugin-dir .` ([DIST-03]) already covers clone-and-run standalone use, and distribution otherwise goes through the central chris-peterson marketplace, so a self-hosted descriptor adds maintenance surface for marginal gain. Standalone self-hosted install is a **non-goal** unless a concrete need arises; reopen with a new ID if it does.

--- a/SPEC.md
+++ b/SPEC.md
@@ -129,8 +129,8 @@ The engine emits at most one decision per invocation.
 - **[HK-02]** The plugin shall register a `SessionStart` hook for plugin-update self-checks. (Currently a no-op placeholder — see [FUT-01].)
 - **[HK-03]** The plugin shall declare its hooks in `hooks/hooks.json`.
 - **[HK-04]** The plugin shall register a `SessionStart` hook that emits ambient guidance into the session context advising that a consequential command be run as its own Bash call rather than piped or chained, so the compound-command escalation ([OUT-08]) is avoided before it triggers. The guidance shall be sourced from `rules/*.md` so it can be edited without changing the hook.
-- **[HK-05]** The plugin shall register a `SessionEnd` hook that deletes the ending session's mute file and its `cwd → session_id` pointer ([HK-06], [MUTE-04]), so a session mute ([MUTE-01]) never outlives its session. `SessionEnd` is non-blocking; the hook's output is advisory and it shall exit 0.
-- **[HK-06]** The plugin shall register a `SessionStart` hook that records a `cwd → session_id` pointer in the mute store ([MUTE-04]), so the mute skill — which does not receive `session_id` (Claude Code supplies it on hook stdin but not as an environment variable to slash commands or bash) — can resolve the active session from its own `cwd`. Where two sessions share a `cwd`, the pointer is last-writer-wins; because the engine's read path ([MUTE-03]) keys on the exact `session_id` from stdin, a collision can misdirect a *write* but never misapply a mute to a session it was not written for.
+- **[HK-05]** The plugin shall register a `SessionEnd` hook that deletes the ending session's mute file ([MUTE-04]), so a session mute ([MUTE-01]) never outlives its session. `SessionEnd` is non-blocking; the hook's output is advisory and it shall exit 0.
+- **[HK-06]** *(superseded 2026-07-09)* — formerly required a `SessionStart` hook recording a `cwd → session_id` pointer so the mute skill could resolve its session without `session_id`, on the premise that Claude Code does not expose `session_id` to a slash command. That premise no longer holds: Claude Code substitutes `${CLAUDE_SESSION_ID}` in skill content, so the mute skill passes the exact session id to the CLI directly ([MUTE-05]). The pointer indirection — and its last-writer-wins collision when two sessions shared a `cwd`, a stale pointer resolving to a dead session, and the `os.getcwd()`-vs-recorded-`cwd` mismatch — is removed; no `SessionStart` hook is needed for mutes.
 
 ## 6. Extensibility (EXT)
 
@@ -185,13 +185,13 @@ trust of [FUT-05]: both suppress `ask` decisions only and neither ever waives a
 repo) and have different lifetimes.
 
 - **[MUTE-01]** A session mute shall suppress `ask` rules only. When a `block` rule matches, the engine shall emit its `deny` regardless of any active mute, mirroring the `except`/`unless_*` law ([RL-08], [RL-15]) that block is un-bypassable. This is the property that makes "let the agent run wild, review at the end" safe: muting `watch-git` silences the recoverable `commit`/`amend`/`reset --hard` prompts while `push --force` and its fellow block rules still fire.
-- **[MUTE-02]** A mute name shall resolve against both rule-set names (e.g. `git` or `watch-git`, muting all that set's `ask` rules) and individual rule names (e.g. `git-commit`, muting that one rule). While a session has an active mute, the engine shall skip — emit no ask for — every matched `ask` rule whose rule `name` or containing rule-set `name` is in that session's mute set, evaluated at the same point as the [RL-07]/[RL-15] exemptions.
-- **[MUTE-03]** The engine shall read the active session's mute set on the decision path keyed by the `session_id` on the hook input ([LOG-03]). Reading the mute set shall be a pure file read with no clock, randomness, or network, so the decision stays deterministic (core contract #1, [EN]): the mute set is a deterministic file input like the `watches/` tree, and `session_id` a deterministic stdin input like `cwd` ([RL-16]). Because expiry cannot be evaluated without a clock on the decision path, a mute shall be scoped to session lifetime — established by the SessionStart/SessionEnd hooks ([HK-05], [HK-06]) — rather than a wall-clock TTL.
+- **[MUTE-02]** A mute token shall resolve against a **rule set** — by its full name (`watch-git`) or short name (`git`), muting all that set's `ask` rules — or an **individual `ask` rule by its `name`** (the descriptive label the ask prompt already shows, e.g. `git commit`). While a session has an active mute, the engine shall skip — emit no ask for — every matched `ask` rule whose rule-set name, rule-set short name, or rule `name` is in that session's mute set, evaluated at the same point as the [RL-07]/[RL-15] exemptions. Rule names are matched exactly; a name that appears in more than one set mutes that rule in each. Keying on the rule `name` rather than a positional id keeps the mute token discoverable (it is the prompt's own label) and stable across rule reordering.
+- **[MUTE-03]** The engine shall read the active session's mute set on the decision path keyed by the `session_id` on the hook input ([LOG-03]). Reading the mute set shall be a pure file read with no clock, randomness, or network, so the decision stays deterministic (core contract #1, [EN]): the mute set is a deterministic file input like the `watches/` tree, and `session_id` a deterministic stdin input like `cwd` ([RL-16]). Because expiry cannot be evaluated without a clock on the decision path, a mute shall be scoped to session lifetime — bounded by the `session_id` it is keyed on and the [HK-05] SessionEnd cleanup — rather than a wall-clock TTL.
 - **[MUTE-04]** The mute set shall be stored per session in the durable user directory `~/.claude/claudewatch/mutes/`, beside the decision log ([LOG-01]) and outside the version-scoped plugin cache, so the fixed path resolves identically for the engine, the mute skill, and the session hooks regardless of installed plugin version (the durability rationale of [FUT-04]). The engine and skill shall restrict the store to owner-only access as the decision log is restricted ([LOG-05]).
-- **[MUTE-05]** The plugin shall ship a skill exposing `/ClaudeWatch:mute <name>`, `/ClaudeWatch:unmute <name>`, and a bare `/ClaudeWatch:mutes` (list the session's active mutes). A natural-language request ("stop asking me about commits this session") shall route to the same skill. The skill shall write and read the [MUTE-04] store for the active session, resolved via the [HK-06] pointer.
+- **[MUTE-05]** The plugin shall ship a skill exposing `/ClaudeWatch:mute <name>`, `/ClaudeWatch:unmute <name>`, and a bare `/ClaudeWatch:mutes` (list the session's active mutes). A natural-language request ("stop asking me about commits this session") shall route to the same skill. The skill shall write and read the [MUTE-04] store for the active session, whose id it obtains from Claude Code's `${CLAUDE_SESSION_ID}` skill-content substitution and passes to the CLI (`--session`) — the same id the engine keys its read on ([MUTE-03]), so a mute lands on exactly the session that requested it.
 - **[MUTE-06]** When the skill applies a mute, it shall confirm explicitly which `ask` rules it disabled for the session — naming each — and how to clear it (`/ClaudeWatch:unmute <name>`), so the user always knows the current suppression state and its undo.
 - **[MUTE-07]** If a mute name resolves to no `ask` rules — a name matching only block rules, or matching nothing — then the skill shall make no change and shall report why ("`<name>` has no ask rules; nothing to mute" / "no rule or rule set named `<name>`"), rather than silently recording an inert mute.
-- **[MUTE-08]** In the `permissionDecisionReason` of an `ask` decision — but not in the logged reasons ([LOG-03]) — the engine should include a display-only hint naming the mute command for the matched rule (e.g. `mute for this session: /ClaudeWatch:mute git-commit`), so the affordance is taught at the point of friction. Like the OSC 8 hyperlink of [OUT-06], the hint is presentation-only.
+- **[MUTE-08]** In the `permissionDecisionReason` of an `ask` decision — but not in the logged reasons ([LOG-03]) — the engine should include a display-only hint naming the mute command for the matched ask rules (e.g. `Mute for this session: /ClaudeWatch:mute 'git commit'`, shell-quoting names with spaces), so the affordance is taught at the point of friction. Like the OSC 8 hyperlink of [OUT-06], the hint is presentation-only.
 
 ## 9. Documentation (DOC)
 
@@ -288,6 +288,22 @@ These describe how the current implementation satisfies the spec. They are
   pattern matching itself runs on the full, unstripped command, so quote
   stripping does not affect which rules fire — only whether a matched `ask` is
   escalated.
+- Session mutes ([MUTE-*]) live under `~/.claude/claudewatch/mutes/`: one
+  `<session_id>.json` (`{"session", "mutes": [...]}`) per session. The engine
+  reads the mute file keyed by the `session_id` on stdin — a pure decision-path
+  read with no clock/network. Mutes key on the rule-set name/short-name or the
+  rule `name` (the label the prompt shows), not a positional id. The write side
+  is a separate stdlib CLI, `scripts/mute.py` (like `analyze-decisions.py`, it
+  imports the shared store-path helpers from `watchdog.py` so the two never
+  disagree); it handles `add`/`remove`/`list` — taking the session id via
+  `--session`, which the skill fills from `${CLAUDE_SESSION_ID}` ([MUTE-05]) —
+  and the `session-end` hook subcommand that deletes the mute file ([HK-05]).
+  `CLAUDEWATCH_HOME` overrides the store root for tests. The three skills
+  (`skills/mute`, `skills/unmute`, `skills/mutes`) are thin wrappers over the CLI
+  and, unlike `rules`/`learn`, are model-invocable so natural language routes to
+  them ([MUTE-05]). The [MUTE-08] hint is appended to the ask reason *after* the
+  decision is logged, so it never reaches the log; it follows a blank line, which
+  the multi-rule line-count test accounts for.
 
 ## 14. Future / Deferred (FUT)
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,14 +1,16 @@
 # ClaudeWatch — Spec Coverage Status
 
-Tracking status of the requirements declared in [SPEC.md](SPEC.md). Updated
-whenever an audit (`/spec-audit`) is run, when implementation lands, or when
-the spec is revised.
+Tracking status of the requirements declared in [SPEC.md](SPEC.md). Maintained by
+`/sextant:spec-status`; updated when a coverage audit runs, when implementation lands,
+or when the spec is revised.
 
-**Last audit:** 2026-06-22
+**Last audit:** 2026-07-08
 **Spec version:** v1 (root SPEC.md, no versioned tree)
-**Coverage:** 85/85 normative requirements (100%) + 3 deferred targets (FUT-01..FUT-03).
-FUT-04..FUT-06 are deferred-discussion notes (rule-edit durability across upgrades,
-repo-scoped git trust, per-repo self-marketplace), not numbered targets.
+**Coverage:** 93 of 103 normative requirements Covered (90%); 10 Missing; 0 Partial. Plus
+5 deferred (FUT-01..FUT-05). Retired, excluded from the count: SK-01, FUT-06. The 10 Missing
+are the unbuilt §8 Session Mute feature ([MUTE-01]..[MUTE-08], [HK-05], [HK-06]), spec'd
+2026-07-08. Counting rule: one distinct `[XX-NN]` = one requirement (lettered decompositions
+included), excluding deferred FUT and retired IDs.
 
 Evidence below points to the authoritative source for each cluster — SPEC.md
 for the contract, `scripts/watchdog.py` for engine behavior, and the per-set
@@ -25,16 +27,19 @@ spot; broader clusters cite the file and its tests.
 | EN-05a | No-arg fallback to `../watches` | Covered | `scripts/watchdog.py:343-346` |
 | LOG-01..LOG-06 | Decision logging side channel: on by default (`CLAUDEWATCH_LOG=off` to opt out), records the command shape rather than the raw command, owner-only perms (0600/0700), schema-versioned header that discards pre-shape logs on upgrade | Covered | `scripts/watchdog.py` (`_log_event`, `command_shape`) + `tests/test-logging.sh` |
 | RS-01..RS-08 | Rule set format, discovery, `extensions` gating | Covered | `scripts/watchdog.py` + `tests/test-engine.sh` |
-| RL-01..RL-14 | Rule fields, `target`, evaluation order, error handling, unrecognized-field warning | Covered | `scripts/watchdog.py` + `tests/test-engine.sh` |
+| RL-01..RL-16 | Rule fields, `target`, evaluation order, error handling, unrecognized-field warning, `unless_regex`/`unless_condition` exemptions + `is_relative_to_cwd` predicate | Covered | `scripts/watchdog.py` + `tests/test-engine.sh` + `tests/test-watch-files.sh` |
 | OUT-01..OUT-08 | Output decisions, formatting, aggregation, allow-by-default, ref hyperlinks (`CLAUDEWATCH_HYPERLINKS`), deny source tag, compound-command ask→deny escalation | Covered | `scripts/watchdog.py` + `tests/test-engine.sh` + `tests/test-output.sh` |
 | HK-01 | PreToolUse hooks for Bash/Write/Edit | Covered | `hooks/hooks.json` |
 | HK-02 | SessionStart hook (no-op placeholder) | Covered | `hooks/hooks.json`, `hooks/cli-freshness.sh` |
 | HK-03 | Hooks declared in hooks.json | Covered | `hooks/hooks.json` |
 | HK-04 | SessionStart ambient guidance emission | Covered | `hooks/emit-rules.sh`, `rules/*.md`, `tests/test-ambient.sh` |
+| HK-05 | SessionEnd deletes session mute file + pointer | Missing | Spec'd 2026-07-08 (MUTE promotion); no `SessionEnd` hook in `hooks/hooks.json` yet |
+| HK-06 | SessionStart writes cwd→session_id pointer for mutes | Missing | Spec'd 2026-07-08; no pointer hook yet |
 | EXT-01..EXT-03 | Auto-discovery, disable-by-rename, no-code-change | Covered | `scripts/watchdog.py`, `tests/test-engine.sh` |
 | SK-01 | `/ClaudeWatch:help` overview *(retired in 0.16.0)* | Removed | README + docs site |
 | SK-02..SK-12 | `/ClaudeWatch:rules` interactive editor | Covered | `skills/rules/SKILL.md` |
-| SK-13..SK-17 | `/ClaudeWatch:learn` decision-log analysis | Covered | `skills/learn/SKILL.md`, `scripts/analyze-decisions.py` |
+| SK-13..SK-19 | `/ClaudeWatch:learn` decision-log analysis, `--since` window + window-provenance reporting, log reset/archive | Covered | `skills/learn/SKILL.md`, `scripts/analyze-decisions.py` |
+| MUTE-01..MUTE-08 | Session mute: per-session `ask` suppression, skill (`/ClaudeWatch:mute`/`unmute`/`mutes`), durable store, friction hint | Missing | Spec'd 2026-07-08 (promoted from FUT-07); no engine read path, hooks, or skill yet |
 | DOC-01, DOC-02, DOC-04, DOC-05 | Docsify site, `just docs` regen (rules + prompts pages), YAML schema reference | Covered | `docs/`, `SCHEMA.md`, `build/gen-rules-doc.py`, `justfile` |
 | DIST-01 | Expose install metadata in manifest | Covered | `.claude-plugin/plugin.json` (name, version, description, repository, license) — hosting/marketplace mechanism is out of scope per SPEC.md |
 | DIST-02 | `.claude-plugin/plugin.json` manifest | Covered | `.claude-plugin/plugin.json` |
@@ -45,10 +50,24 @@ spot; broader clusters cite the file and its tests.
 | SH-04 | Per-set test files | Covered | `tests/test-watch-*.sh` |
 | DEV-01..DEV-04 | `just test`, test layout, `just rules`, `just docs-preview` | Covered | `justfile` + `tests/` |
 | FUT-01 | SessionStart self-check | Deferred | `hooks/cli-freshness.sh` is intentional no-op |
-| FUT-02 | `new` rule-set scaffolds a test file | Deferred — partially covered | `skills/rules/SKILL.md` already offers this; consider promoting |
+| FUT-02 | `new` rule-set scaffolds a test file | Deferred | `skills/rules/SKILL.md` offers post-write test *coverage* but scaffolds no test *file* for a `new` set; [FUT-02] now specifies the file scaffold |
 | FUT-03 | Multi-line YAML strings / anchors | Deferred | Not needed by current rules |
 
 ## Audit history
+
+### 2026-07-08 — Coverage refresh (spec-status)
+
+STATUS.md regenerated: coverage recomputed to 93 Covered / 10 Missing / 0 Partial of 103 normative (+5 deferred FUT-01..05; SK-01/FUT-06 retired-excluded); MUTE-01..08 + HK-05/06 classified Missing; status vocab and coverage line canonicalized. Supersedes the manual recount below — the tool is `/sextant:spec-status`, not the retired `/spec-audit`.
+
+### 2026-07-08 — FUT audit + Session Mute promotion (manual spec revision)
+
+Spec revised (SPEC.md) and coverage recounted by hand (the `/spec-audit` tooling no longer exists):
+
+- **Promoted the former FUT-07 to a normative feature.** New §8 **Session Mute** ([MUTE-01]..[MUTE-08]) plus [HK-05]/[HK-06], and amended the §1 core contract to admit the session mute set as a deterministic decision input. Not yet implemented (no engine read path, hooks, or skill) — table rows added as *Not implemented*.
+- **Recounted coverage: 85 → 93/103.** The old "85/85 100%" was stale — [RL-15]/[RL-16] (`unless_*` exemptions + `is_relative_to_cwd`) and [SK-18]/[SK-19] (`--since` window provenance, log reset/archive) were implemented and tested but had never been tabled. Added those to their cluster rows. New counting rule recorded in the header. The 10-requirement gap to 103 is entirely the unbuilt Session Mute feature.
+- **Audited the deferred list.** FUT-01/03/04/05 remain relevant; FUT-04 and FUT-05 re-pointed at [MUTE-04] now that the durable user directory is concrete rather than hypothetical. FUT-02 refined to specify scaffolding the test *file* (the rules skill offers test *cases* today but no file for a `new` set).
+- **FUT-06 declined** as a non-goal (standalone self-marketplace) and tombstoned in house style (per the retired [SK-01]); its ID is preserved because CHANGELOG.md and this file reference it.
+- **Known drift (not fixed here):** sibling plugins' `STATUS.md` and the ai-sdlc convention still name the removed `/spec-audit` command — captured as a deferred logbook note for the retro.
 
 ### 2026-06-22 — Coverage refresh (spec-status)
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,13 +4,12 @@ Tracking status of the requirements declared in [SPEC.md](SPEC.md). Maintained b
 `/sextant:spec-status`; updated when a coverage audit runs, when implementation lands,
 or when the spec is revised.
 
-**Last audit:** 2026-07-08
+**Last audit:** 2026-07-09
 **Spec version:** v1 (root SPEC.md, no versioned tree)
-**Coverage:** 93 of 103 normative requirements Covered (90%); 10 Missing; 0 Partial. Plus
-5 deferred (FUT-01..FUT-05). Retired, excluded from the count: SK-01, FUT-06. The 10 Missing
-are the unbuilt §8 Session Mute feature ([MUTE-01]..[MUTE-08], [HK-05], [HK-06]), spec'd
-2026-07-08. Counting rule: one distinct `[XX-NN]` = one requirement (lettered decompositions
-included), excluding deferred FUT and retired IDs.
+**Coverage:** 102 of 102 normative requirements Covered (100%); 0 Missing; 0 Partial. Plus
+5 deferred (FUT-01..FUT-05). Retired/superseded, excluded from the count: SK-01, HK-06, FUT-06.
+Counting rule: one distinct `[XX-NN]` = one requirement (lettered decompositions included),
+excluding deferred FUT and retired/superseded IDs.
 
 Evidence below points to the authoritative source for each cluster — SPEC.md
 for the contract, `scripts/watchdog.py` for engine behavior, and the per-set
@@ -33,13 +32,13 @@ spot; broader clusters cite the file and its tests.
 | HK-02 | SessionStart hook (no-op placeholder) | Covered | `hooks/hooks.json`, `hooks/cli-freshness.sh` |
 | HK-03 | Hooks declared in hooks.json | Covered | `hooks/hooks.json` |
 | HK-04 | SessionStart ambient guidance emission | Covered | `hooks/emit-rules.sh`, `rules/*.md`, `tests/test-ambient.sh` |
-| HK-05 | SessionEnd deletes session mute file + pointer | Missing | Spec'd 2026-07-08 (MUTE promotion); no `SessionEnd` hook in `hooks/hooks.json` yet |
-| HK-06 | SessionStart writes cwd→session_id pointer for mutes | Missing | Spec'd 2026-07-08; no pointer hook yet |
+| HK-05 | SessionEnd deletes session mute file | Covered | `hooks/hooks.json`, `scripts/mute.py` (`session-end`) + `tests/test-mutes.sh` |
+| HK-06 | SessionStart cwd→session_id pointer for mutes *(superseded 2026-07-09)* | Removed | Skill uses `${CLAUDE_SESSION_ID}`; SPEC [HK-06] |
 | EXT-01..EXT-03 | Auto-discovery, disable-by-rename, no-code-change | Covered | `scripts/watchdog.py`, `tests/test-engine.sh` |
 | SK-01 | `/ClaudeWatch:help` overview *(retired in 0.16.0)* | Removed | README + docs site |
 | SK-02..SK-12 | `/ClaudeWatch:rules` interactive editor | Covered | `skills/rules/SKILL.md` |
 | SK-13..SK-19 | `/ClaudeWatch:learn` decision-log analysis, `--since` window + window-provenance reporting, log reset/archive | Covered | `skills/learn/SKILL.md`, `scripts/analyze-decisions.py` |
-| MUTE-01..MUTE-08 | Session mute: per-session `ask` suppression, skill (`/ClaudeWatch:mute`/`unmute`/`mutes`), durable store, friction hint | Missing | Spec'd 2026-07-08 (promoted from FUT-07); no engine read path, hooks, or skill yet |
+| MUTE-01..MUTE-08 | Session mute: per-session `ask` suppression, skill (`/ClaudeWatch:mute`/`unmute`/`mutes`), durable store, friction hint | Covered | `scripts/watchdog.py` (`load_session_mutes`, ask-loop skip, hint), `scripts/mute.py`, `skills/{mute,unmute,mutes}/SKILL.md` + `tests/test-mutes.sh` |
 | DOC-01, DOC-02, DOC-04, DOC-05 | Docsify site, `just docs` regen (rules + prompts pages), YAML schema reference | Covered | `docs/`, `SCHEMA.md`, `build/gen-rules-doc.py`, `justfile` |
 | DIST-01 | Expose install metadata in manifest | Covered | `.claude-plugin/plugin.json` (name, version, description, repository, license) — hosting/marketplace mechanism is out of scope per SPEC.md |
 | DIST-02 | `.claude-plugin/plugin.json` manifest | Covered | `.claude-plugin/plugin.json` |
@@ -54,6 +53,14 @@ spot; broader clusters cite the file and its tests.
 | FUT-03 | Multi-line YAML strings / anchors | Deferred | Not needed by current rules |
 
 ## Audit history
+
+### 2026-07-09 — Session-mute pointer removed (manual revision)
+
+The mute skill now passes the active session id via `--session` from Claude Code's `${CLAUDE_SESSION_ID}` skill substitution, so the CLI no longer bridges through a `cwd → session_id` pointer. [HK-06] (the SessionStart pointer hook) is superseded and excluded from the count (103 → 102); [HK-05] no longer deletes a pointer. This removes the pointer's failure modes: a wrong-session write when two sessions shared a `cwd`, a stale pointer resolving to a dead session, and the `os.getcwd()`-vs-recorded-`cwd` mismatch. Folded in alongside are review fixes — a guarded rule parse in the CLI (one malformed set warns and skips instead of crashing), no whole-set hint for a nameless ask rule, deduped mute-hint tokens, a shell-quoted unmute suggestion, and a dropped redundant post-write read. Coverage recounted by hand; a `/sextant:spec-status` regen should confirm. `tests/test-mutes.sh` updated (session id via `--session`, no pointer).
+
+### 2026-07-08 — Session Mute implemented
+
+MUTE-01..08 + HK-05/HK-06 implemented and tested; coverage 93 → 103/103 (100%). The engine reads the per-session mute set on the decision path (`load_session_mutes`, ask-loop skip, [MUTE-08] hint); `scripts/mute.py` is the write/read CLI plus the SessionStart/SessionEnd hook subcommands; three model-invocable skills (`mute`/`unmute`/`mutes`) wrap it; `tests/test-mutes.sh` (20 cases) covers engine suppression, block-still-fires, the hint, the CLI, and the session lifecycle. Individual rules are muted by their `name` (the label the ask prompt shows, e.g. `git commit`), not a positional id — discoverable and stable across reordering; the engine matches the rule-set name/short-name or the rule name.
 
 ### 2026-07-08 — Coverage refresh (spec-status)
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -33,6 +33,16 @@
           }
         ]
       }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/mute.py session-end"
+          }
+        ]
+      }
     ]
   }
 }

--- a/hooks/hooks.yml
+++ b/hooks/hooks.yml
@@ -14,3 +14,6 @@ hooks:
   - event: SessionStart
     command: 'bash ${CLAUDE_PLUGIN_ROOT}/hooks/emit-rules.sh'
     description: Emit ClaudeWatch's ambient guidance into context.
+  - event: SessionEnd
+    command: 'python3 ${CLAUDE_PLUGIN_ROOT}/scripts/mute.py session-end'
+    description: Clear this session's rule-set mutes when the session ends.

--- a/plugin.yml
+++ b/plugin.yml
@@ -32,19 +32,23 @@ suite:
   cmds:
     - ["/ClaudeWatch:rules", "See and edit the rule sets that guard your commands"]
     - ["/ClaudeWatch:learn", "Tune the rules from what's been prompting you"]
+    - ["/ClaudeWatch:mute", "Silence a rule set's ask prompts for this session"]
   # The automatic block/ask flow is the primary interaction (see session: below);
   # these examples are anchored on the two skills, for when you look under the hood.
   # >>> shipyard:describe — generated from source by `shipyard gen-describe`; do not edit >>>
   describe:
     skills:
       learn: Analyze the ClaudeWatch decision log to find commands that repeatedly prompt, and propose allow-list entries and rule tweaks that cut prompt fatigue — reviewed as one batch, then reset the log.
+      mute: Silence a ClaudeWatch rule set's or ask rule's confirmation prompts for the rest of this session — for when a chatty recipe keeps prompting on recoverable ops (commit, amend, stash) and you want to review at the end.
+      mutes: List the ClaudeWatch rule sets and ask rules muted for this session.
       rules: View and interactively edit ClaudeWatch safety rules — list each rule set's block/ask rules as tables, then add, move, or remove rules, toggle whole rule sets on/off, or scaffold a new set, with conflict detection, a preview, and a test run before writing.
+      unmute: Clear a ClaudeWatch session mute so its confirmation prompts return.
     rules:
       avoid-compound-commands: Before you pipe or chain, check the lead command
     hooks:
       cli-freshness: SessionStart — No-op; ClaudeWatch ships no CLI.
       emit-rules: SessionStart — Emit ClaudeWatch's ambient guidance into context.
-      hooks: 'Hook wiring: PreToolUse→watchdog (Bash, Write|Edit); SessionStart→cli-freshness, emit-rules.'
+      hooks: 'Hook wiring: PreToolUse→watchdog (Bash, Write|Edit); SessionStart→cli-freshness, emit-rules; SessionEnd→mute.'
   # <<< shipyard:describe <<<
   examples:
     - label: "/ClaudeWatch:rules"

--- a/scripts/mute.py
+++ b/scripts/mute.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""
+mute: manage per-session ClaudeWatch mutes ([MUTE-01..MUTE-08], [HK-05]).
+
+A *session mute* silences a rule set's or an individual ask rule's prompts for
+the duration of one Claude Code session. Mutes suppress *ask* rules only — block
+rules are never mutable ([MUTE-01]). This is the write/read side of the feature;
+the engine (`watchdog.py`) does the read on the decision path.
+
+Subcommands:
+  add <name>...      mute a rule set (`git` / `watch-git`) or ask rule (`git commit`)
+  remove <name>...   clear a mute
+  list               show this session's active mutes
+  session-end        (SessionEnd hook, [HK-05]) delete this session's mute file
+
+`add` / `remove` / `list` take the active session id via `--session`, which the
+mute skill supplies from Claude Code's `${CLAUDE_SESSION_ID}` skill substitution
+([MUTE-05]) — the same id the engine keys its read on, so a mute always lands on
+the session that requested it. Individual rules are named by the same label the
+ask prompt shows (e.g. `git commit`), not a positional id, so the token is
+discoverable and doesn't drift when rules move. Read-only of the rules,
+stdlib-only, no network. The store path comes from `watchdog` so the engine and
+this tool agree.
+"""
+
+import argparse
+import glob
+import json
+import os
+import shlex
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from watchdog import (  # noqa: E402
+    parse_rules_yml,
+    load_session_mutes,
+    mutes_dir,
+    mute_file,
+    short_set_name,
+    valid_session_id,
+)
+
+DEFAULT_WATCHES = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "watches")
+
+
+def load_catalog(watches_dir):
+    """Index the enabled rule sets into the lookups `resolve` needs.
+
+    Returns a dict with:
+      set_asks:    short -> [ask rule name, ...]  (file order)
+      set_full:    short -> full set name (`watch-git`)
+      set_block:   short -> bool (has any block rule)
+      ask_names:   set of every ask rule name
+      block_names: set of every block rule name
+    """
+    cat = {"set_asks": {}, "set_full": {}, "set_block": {},
+           "ask_names": set(), "block_names": set()}
+    for path in sorted(glob.glob(os.path.join(watches_dir, "*.yml"))):
+        try:
+            config = parse_rules_yml(path)
+        except Exception as e:
+            # The engine degrades a malformed rule set to a deny and moves on
+            # (watchdog.main); the CLI has no decision to make, so surface the
+            # bad file on stderr and skip it rather than crash the whole mute
+            # command over one unreadable set.
+            print(f"mute: skipping unreadable rule set {os.path.basename(path)}: {e}", file=sys.stderr)
+            continue
+        name = config.get("name") or ""
+        if not name:
+            continue
+        short = short_set_name(name)
+        cat["set_full"][short] = name
+        rules = config.get("rules", {})
+        asks = [r.get("name") for r in rules.get("ask", []) if r.get("name")]
+        cat["set_asks"][short] = asks
+        cat["ask_names"].update(asks)
+        blocks = rules.get("block", [])
+        cat["set_block"][short] = bool(blocks)
+        cat["block_names"].update(r.get("name") for r in blocks if r.get("name"))
+    return cat
+
+
+def resolve(token, cat):
+    """Map a user token to a mute decision.
+
+    Returns (canonical, silenced, note):
+      canonical — the token to store (set short name or rule name), or None to skip
+      silenced  — list of ask rule names this mute silences
+      note      — a message to show the user (why it was a no-op), or None
+    """
+    short = token[len("watch-"):] if token.startswith("watch-") else token
+    if short in cat["set_full"]:
+        asks = cat["set_asks"].get(short, [])
+        if not asks:
+            extra = " (its rules are all block rules, which are un-bypassable)" if cat["set_block"].get(short) else ""
+            return None, [], f"'{token}' has no ask rules; nothing to mute{extra}"
+        return short, asks, None
+    if token in cat["ask_names"]:
+        return token, [token], None
+    if token in cat["block_names"]:
+        return None, [], f"'{token}' is a block rule; block rules are un-bypassable and can't be muted"
+    return None, [], f"no rule or rule set named '{token}'"
+
+
+def _session_or_error(args):
+    """The active session id from `--session`, or None after explaining the miss.
+
+    The mute skill passes `${CLAUDE_SESSION_ID}` here ([MUTE-05]); it is the same
+    id the engine keys its read on, so no cwd/pointer indirection is involved.
+    """
+    if not args.session:
+        print("Could not resolve the active ClaudeWatch session.\n"
+              "The mute skill supplies it via --session \"${CLAUDE_SESSION_ID}\"; run "
+              "/ClaudeWatch:mute, /ClaudeWatch:unmute, or /ClaudeWatch:mutes rather than "
+              "invoking mute.py directly.")
+        return None
+    if not valid_session_id(args.session):
+        print(f"Ignoring an unsafe ClaudeWatch session id: {args.session!r}.\n"
+              "Expected the id Claude Code supplies via --session \"${CLAUDE_SESSION_ID}\".")
+        return None
+    return args.session
+
+
+def _write_mutes(session_id, names):
+    os.makedirs(mutes_dir(), mode=0o700, exist_ok=True)
+    dest = mute_file(session_id)
+    with open(dest, "w") as f:
+        json.dump({"session": session_id, "mutes": sorted(names)}, f)
+    os.chmod(dest, 0o600)
+
+
+def _describe_asks(names, indent="  "):
+    return "\n".join(f"{indent}{name}" for name in names)
+
+
+def cmd_add(args):
+    session_id = _session_or_error(args)
+    if not session_id:
+        return 0
+    cat = load_catalog(args.watches)
+    current = load_session_mutes(session_id)
+    added, silenced, notes = [], [], []
+    for token in args.names:
+        canonical, asks, note = resolve(token, cat)
+        if note:
+            notes.append(note)
+            continue
+        if canonical in current:
+            notes.append(f"'{token}' was already muted")
+            continue
+        current.add(canonical)
+        added.append(canonical)
+        silenced.extend(asks)
+    if added:
+        _write_mutes(session_id, current)
+    for note in notes:
+        print(note)
+    if added:
+        # Dedup silenced ask names while preserving order.
+        seen, unique = set(), []
+        for name in silenced:
+            if name not in seen:
+                seen.add(name)
+                unique.append(name)
+        print(f"Muted {', '.join(added)} for this session. These ask prompts are now silenced:")
+        print(_describe_asks(unique))
+        print("Block rules still apply.")
+        print(f"Clear with: /ClaudeWatch:unmute {' '.join(shlex.quote(a) for a in added)}")
+    elif not notes:
+        print("Nothing to mute.")
+    return 0
+
+
+def cmd_remove(args):
+    session_id = _session_or_error(args)
+    if not session_id:
+        return 0
+    cat = load_catalog(args.watches)
+    current = load_session_mutes(session_id)
+    removed, notes = [], []
+    for token in args.names:
+        canonical, _asks, note = resolve(token, cat)
+        # Even if the token no longer resolves (e.g. a renamed rule), allow
+        # removing the raw token so a stale mute can always be cleared.
+        target = canonical if canonical in current else token
+        if target in current:
+            current.discard(target)
+            removed.append(target)
+        else:
+            notes.append(note or f"'{token}' was not muted")
+    if removed:
+        _write_mutes(session_id, current)
+    for note in notes:
+        print(note)
+    if removed:
+        print(f"Unmuted {', '.join(removed)} for this session.")
+        # `current` already holds the post-removal set that was just written; no
+        # need to re-read the store.
+        print("No active mutes remain." if not current else f"Still muted: {', '.join(sorted(current))}")
+    return 0
+
+
+def cmd_list(args):
+    session_id = _session_or_error(args)
+    if not session_id:
+        return 0
+    current = load_session_mutes(session_id)
+    if not current:
+        print("No active mutes for this session.")
+        return 0
+    cat = load_catalog(args.watches)
+    print("Active mutes for this session:")
+    for token in sorted(current):
+        _canonical, asks, _note = resolve(token, cat)
+        print(f"- {token}")
+        if asks and asks != [token]:
+            print(_describe_asks(asks, indent="    "))
+    return 0
+
+
+def _read_hook_input():
+    try:
+        return json.loads(sys.stdin.read() or "{}")
+    except (ValueError, OSError):
+        return {}
+
+
+def cmd_session_end(_args):
+    """[HK-05] Delete this session's mute file so a mute never outlives its session."""
+    data = _read_hook_input()
+    session_id = data.get("session_id")
+    if not session_id:
+        return 0
+    try:
+        os.remove(mute_file(session_id))
+    except (OSError, ValueError):
+        pass
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Manage per-session ClaudeWatch mutes.")
+    parser.add_argument("--watches", default=DEFAULT_WATCHES, help="rule-sets directory")
+    parser.add_argument("--session", default=None,
+                        help="active session id (the mute skill passes ${CLAUDE_SESSION_ID})")
+    sub = parser.add_subparsers(dest="command", required=True)
+    p_add = sub.add_parser("add"); p_add.add_argument("names", nargs="+")
+    p_rm = sub.add_parser("remove"); p_rm.add_argument("names", nargs="+")
+    sub.add_parser("list")
+    sub.add_parser("session-end")
+
+    args = parser.parse_args()
+
+    handlers = {
+        "add": cmd_add, "remove": cmd_remove, "list": cmd_list,
+        "session-end": cmd_session_end,
+    }
+    sys.exit(handlers[args.command](args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/watchdog.py
+++ b/scripts/watchdog.py
@@ -39,6 +39,64 @@ import sys
 VALID_TARGETS = ("bash", "file-content")
 
 
+# --- Session mute store (MUTE-01..MUTE-04) ------------------------------------
+# A session mute suppresses *ask* rules (never block rules) for the duration of
+# one Claude Code session. The engine reads the muted-name set keyed by the
+# hook's session_id — a pure file read on the decision path, no clock/network,
+# so determinism holds ([EN], MUTE-03). The store lives in a fixed user
+# directory so its path resolves identically for the engine, the `mute.py` CLI,
+# and the session hooks regardless of installed plugin version (MUTE-04).
+# CLAUDEWATCH_HOME overrides the root (used by tests); default ~/.claude/claudewatch.
+
+def _claudewatch_home():
+    return os.path.expanduser(os.environ.get("CLAUDEWATCH_HOME") or "~/.claude/claudewatch")
+
+
+def mutes_dir():
+    return os.path.join(_claudewatch_home(), "mutes")
+
+
+# A session id comes from Claude Code (a UUID) or the hook's `session_id`, and
+# is the only place that value is used as a path component. Validate it before
+# it becomes a filename so a stray separator or `..` segment can't escape the
+# mutes directory.
+_SAFE_SESSION_ID = re.compile(r"[A-Za-z0-9_-]+")
+
+
+def valid_session_id(session_id):
+    """True when session_id is safe to use as a mute-file name (no path parts)."""
+    return isinstance(session_id, str) and _SAFE_SESSION_ID.fullmatch(session_id) is not None
+
+
+def mute_file(session_id):
+    if not valid_session_id(session_id):
+        raise ValueError(f"unsafe session id: {session_id!r}")
+    return os.path.join(mutes_dir(), f"{session_id}.json")
+
+
+def short_set_name(set_name):
+    """The `/ClaudeWatch:rules` short name: the set name minus its `watch-` prefix."""
+    return set_name[len("watch-"):] if set_name.startswith("watch-") else set_name
+
+
+def load_session_mutes(session_id):
+    """Return the set of muted names for a session (empty when none/unreadable).
+
+    A pure read on the decision path (MUTE-03): a missing or malformed store is
+    an empty mute set, never an error — silence is allow, and a broken mute file
+    must never turn a normal ask into anything else.
+    """
+    if not session_id:
+        return set()
+    try:
+        with open(mute_file(session_id)) as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return set()
+    mutes = data.get("mutes") if isinstance(data, dict) else data
+    return set(mutes) if isinstance(mutes, (list, set)) else set()
+
+
 def _unquote(s):
     if len(s) >= 2 and s[0] == "'" and s[-1] == "'":
         return s[1:-1].replace("''", "'")
@@ -419,14 +477,17 @@ def _compound_escalation():
     }
 
 
-def evaluate_rules(config, input_kind, input_text, file_extension=None, cwd=None):
+def evaluate_rules(config, input_kind, input_text, file_extension=None, cwd=None, muted=None):
     """Evaluate a single rule set against an input.
 
     input_kind is "bash" or "file-content". input_text is the string to match
     against. file_extension is the lowercase extension (including the dot) of
     the target file, used to filter rule sets for file-content inputs. cwd is
     the working directory from the hook input, used by the `is_relative_to_cwd`
-    unless-condition to tell in-tree deletes from out-of-tree ones.
+    unless-condition to tell in-tree deletes from out-of-tree ones. muted is the
+    active session's set of muted names ([MUTE-02]); a matched ask rule is
+    skipped when its rule-set name, rule-set short name, or rule name is muted.
+    Block rules ignore `muted` entirely ([MUTE-01]).
 
     Returns (blocks, asks) — lists of violation dicts (see `_violation`).
     """
@@ -494,7 +555,20 @@ def evaluate_rules(config, input_kind, input_text, file_extension=None, cwd=None
             continue
         if exempted:
             continue
-        asks.append(_violation(rule))
+        rule_name = rule.get("name") or ""
+        # A session mute suppresses this ask when its rule-set name, rule-set
+        # short name, or rule name is muted ([MUTE-02]). Block rules never
+        # consult this. Matching on the rule name (not a positional id) keeps the
+        # mute token the same label the ask prompt already shows.
+        if muted and ({label, short_set_name(label), rule_name} & muted):
+            continue
+        violation = _violation(rule)
+        # The friction hint ([MUTE-08]) suggests muting this specific rule by its
+        # name. A nameless ask rule has no per-rule token; falling back to the set
+        # short name would suggest a command that silences the whole set, so leave
+        # it empty (the hint filters falsy tokens) rather than over-mute.
+        violation["mute_token"] = rule_name
+        asks.append(violation)
 
     return blocks, asks
 
@@ -694,6 +768,7 @@ def main():
         sys.exit(0)
     input_kind, input_text, file_extension = resolved
     cwd = data.get("cwd")
+    muted = load_session_mutes(data.get("session_id"))
 
     if len(sys.argv) > 1:
         target = sys.argv[1]
@@ -726,7 +801,7 @@ def main():
         except Exception as e:
             all_blocks.append(_error_violation(f"watchdog: failed to load rules: {e}"))
             continue
-        blocks, asks = evaluate_rules(config, input_kind, input_text, file_extension, cwd)
+        blocks, asks = evaluate_rules(config, input_kind, input_text, file_extension, cwd, muted)
         all_blocks.extend(blocks)
         all_asks.extend(asks)
 
@@ -758,6 +833,22 @@ def main():
         # match — the user should always see which plugin made the call.
         if decision == "deny":
             reason += f" {_PLUGIN_TAG}"
+        # Teach the mute affordance at the point of friction ([MUTE-08]): a
+        # display-only hint naming the mute command for the matched ask rules.
+        # It is appended after `_log_event` above, so it never reaches the log.
+        if decision == "ask":
+            # Dedup while preserving order: two matched ask rules can share a
+            # rule name (same `name` in different sets), which would otherwise
+            # repeat the token in the suggested command.
+            seen, tokens = set(), []
+            for v in chosen:
+                t = v.get("mute_token")
+                if t and t not in seen:
+                    seen.add(t)
+                    tokens.append(t)
+            if tokens:
+                quoted = " ".join(shlex.quote(t) for t in tokens)
+                reason += "\n\nMute for this session: /ClaudeWatch:mute " + quoted
         _emit(decision, reason)
 
     sys.exit(0)

--- a/skills/mute/SKILL.md
+++ b/skills/mute/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: mute
+description: >
+  Silence a ClaudeWatch rule set's or ask rule's confirmation prompts for the
+  rest of this session — for when a chatty recipe keeps prompting on recoverable
+  ops (commit, amend, stash) and you want to review at the end. Use when the user
+  says "mute", "stop asking me about <X> this session", "let it run without
+  prompting on <X>", or similar. Silences ask rules only; block rules still fire.
+---
+
+# ClaudeWatch — mute
+
+A **session mute** silences a rule set's or an individual ask rule's prompts for
+the duration of this Claude Code session. It suppresses **ask** rules only —
+**block** rules (e.g. `git push --force`) always fire, so muting is safe for the
+"let the agent run wild, review at the end" workflow: only the *recoverable*
+prompts go quiet.
+
+Mutes are per-session and clear themselves when the session ends.
+
+## What can be muted
+
+- **A whole rule set** — its short name (`git`) or full name (`watch-git`). Mutes
+  every ask rule in the set.
+- **A single ask rule** — its name, the label the ask prompt shows (e.g.
+  `git commit`). Pass a name with spaces as a single quoted argument.
+
+Block rules can't be muted; asking to mute one (or a set with no ask rules) is
+reported as a no-op.
+
+## Steps
+
+1. **Resolve the target from the request.** If the user named a rule set or id
+   directly, use it. For natural language ("stop asking me about commits"), map
+   it to the narrowest matching token — prefer a specific ask rule over the whole
+   set when the intent is specific. If you're unsure which rule they mean, run
+   `/ClaudeWatch:rules --list` to see the rule names, then pick.
+
+2. **Apply the mute** by running the CLI, passing the active session id (Claude
+   Code expands `${CLAUDE_SESSION_ID}` for you):
+
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT}/scripts/mute.py" --watches "${CLAUDE_PLUGIN_ROOT}/watches" --session "${CLAUDE_SESSION_ID}" add <name> [<name>...]
+   ```
+
+   Pass a multi-word rule name as a single quoted argument (`"git commit"`).
+
+3. **Relay the CLI's output verbatim** — it names exactly which ask prompts are
+   now silenced and how to clear them (`/ClaudeWatch:unmute <name>`). Don't
+   summarize it away; the explicit list is the point ([MUTE-06]).
+
+If the CLI reports it could not resolve the active session, the
+`${CLAUDE_SESSION_ID}` placeholder did not expand — run the command from this
+skill rather than pasting it by hand, so Claude Code substitutes the real id.
+
+## Related
+
+- `/ClaudeWatch:unmute <name>` — clear a mute.
+- `/ClaudeWatch:mutes` — list this session's active mutes.
+- `/ClaudeWatch:rules` — see rule-set names and the individual rule names.

--- a/skills/mutes/SKILL.md
+++ b/skills/mutes/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: mutes
+description: >
+  List the ClaudeWatch rule sets and ask rules muted for this session. Use when
+  the user asks "what's muted?", "show mutes", or "list session mutes".
+---
+
+# ClaudeWatch — mutes
+
+Show which rule sets and ask rules are silenced for this session, and the exact
+ask prompts each one covers.
+
+## Steps
+
+1. **List the active mutes:**
+
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT}/scripts/mute.py" --watches "${CLAUDE_PLUGIN_ROOT}/watches" --session "${CLAUDE_SESSION_ID}" list
+   ```
+
+2. **Relay the output.** If nothing is muted, say so. Otherwise present the muted
+   tokens and the ask prompts they silence, and mention `/ClaudeWatch:unmute
+   <name>` to clear one.
+
+## Related
+
+- `/ClaudeWatch:mute <name>` — mute a rule set or ask rule for the session.
+- `/ClaudeWatch:unmute <name>` — clear a mute.

--- a/skills/unmute/SKILL.md
+++ b/skills/unmute/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: unmute
+description: >
+  Clear a ClaudeWatch session mute so its confirmation prompts return. Use when
+  the user says "unmute", "re-enable prompts for <X>", or "stop muting <X>".
+---
+
+# ClaudeWatch — unmute
+
+Clear a mute set earlier this session with `/ClaudeWatch:mute`, so that rule set
+or ask rule prompts again for the rest of the session.
+
+## Steps
+
+1. **Resolve the target** the same way `/ClaudeWatch:mute` does — a rule-set name
+   (`git` / `watch-git`) or an ask rule name (`git commit`). Run
+   `/ClaudeWatch:mutes` first if you're unsure what's currently muted.
+
+2. **Clear the mute:**
+
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT}/scripts/mute.py" --watches "${CLAUDE_PLUGIN_ROOT}/watches" --session "${CLAUDE_SESSION_ID}" remove <name> [<name>...]
+   ```
+
+3. **Relay the CLI's output** — it confirms what was unmuted and what mutes, if
+   any, remain.
+
+## Related
+
+- `/ClaudeWatch:mute <name>` — mute a rule set or ask rule for the session.
+- `/ClaudeWatch:mutes` — list this session's active mutes.

--- a/tests/test-mutes.sh
+++ b/tests/test-mutes.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Session mute tests ([MUTE-01..MUTE-08], [HK-05]).
+source "$(cd "$(dirname "$0")" && pwd)/harness.sh"
+
+# Isolate the mute store in a temp home so the suite never touches the real one.
+export CLAUDEWATCH_HOME="$(mktemp -d)"
+MUTES="$CLAUDEWATCH_HOME/mutes"
+mkdir -p "$MUTES"
+MUTE="$SCRIPT_DIR/../scripts/mute.py"
+GIT="$RULES_DIR/watch-git.yml"
+SESS="test-session-1"
+
+# Individual ask rules are muted by their name (the label the prompt shows),
+# e.g. "git commit" / "git reset --hard".
+
+check() {  # label, haystack, needle
+  local label="$1" hay="$2" needle="$3"
+  TOTAL=$((TOTAL + 1))
+  if printf '%s' "$hay" | grep -qF -- "$needle"; then
+    PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC}: $label"
+  else
+    FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC}: $label (missing: $needle)"
+  fi
+}
+
+check_absent() {  # label, haystack, needle
+  local label="$1" hay="$2" needle="$3"
+  TOTAL=$((TOTAL + 1))
+  if printf '%s' "$hay" | grep -qF -- "$needle"; then
+    FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC}: $label (unexpected: $needle)"
+  else
+    PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC}: $label"
+  fi
+}
+
+inp() {  # command -> hook input JSON carrying the test session id
+  printf '{"tool_name":"Bash","tool_input":{"command":"%s"},"session_id":"%s"}' "$1" "$SESS"
+}
+
+echo "=== engine honors a session mute ([MUTE-01..MUTE-03]) ==="
+
+printf '{"mutes":["git"]}' > "$MUTES/$SESS.json"
+run_test "$GIT" "muted set 'git': git commit is allowed"        allow "$(inp 'git commit -m x')"
+run_test "$GIT" "muted set 'git': git reset --hard is allowed"  allow "$(inp 'git reset --hard')"
+run_test "$GIT" "muted set 'git': block (push --force) still fires" block "$(inp 'git push --force')"
+
+printf '{"mutes":["git commit"]}' > "$MUTES/$SESS.json"
+run_test "$GIT" "muted rule 'git commit': git commit is allowed"        allow "$(inp 'git commit -m x')"
+run_test "$GIT" "muted rule 'git commit': git reset --hard still asks"  ask   "$(inp 'git reset --hard')"
+
+rm -f "$MUTES/$SESS.json"
+run_test "$GIT" "no mute: git commit asks as normal"            ask   "$(inp 'git commit -m x')"
+
+echo "=== friction hint on the ask prompt ([MUTE-08]) ==="
+hint_out=$(inp 'git commit -m x' | python3 "$HOOK" "$GIT" 2>/dev/null || true)
+check "ask reason carries the mute hint" "$hint_out" "Mute for this session: /ClaudeWatch:mute 'git commit'"
+block_out=$(printf '{"tool_name":"Bash","tool_input":{"command":"git push --force"},"session_id":"%s"}' "$SESS" | python3 "$HOOK" "$GIT" 2>/dev/null || true)
+check_absent "block reason carries no mute hint" "$block_out" "Mute for this session"
+
+echo "=== CLI: --session add, list, remove, no-ops ([MUTE-04..MUTE-07]) ==="
+# The skill passes the session id via --session ${CLAUDE_SESSION_ID}; the id
+# matches the one the engine reads on stdin, so the write lands where the read
+# looks — no cwd/pointer indirection.
+add_out=$(python3 "$MUTE" --watches "$RULES_DIR" --session "$SESS" add git)
+check "add 'git' names the silenced commit rule" "$add_out" "git commit"
+check "add 'git' explains how to clear"          "$add_out" "/ClaudeWatch:unmute git"
+check "add 'git' notes block rules still apply"  "$add_out" "Block rules still apply"
+check "mute file records the canonical token"    "$(cat "$MUTES/$SESS.json")" '"git"'
+run_test "$GIT" "CLI-applied mute silences git commit" allow "$(inp 'git commit -m x')"
+
+no_session_out=$(python3 "$MUTE" --watches "$RULES_DIR" add git 2>&1)
+check "add without --session reports the miss" "$no_session_out" "Could not resolve the active ClaudeWatch session"
+
+noop_out=$(python3 "$MUTE" --watches "$RULES_DIR" --session "$SESS" add "git push --force")
+check "muting a block rule is a reported no-op" "$noop_out" "block rules are un-bypassable"
+unknown_out=$(python3 "$MUTE" --watches "$RULES_DIR" --session "$SESS" add nonesuch)
+check "muting an unknown name is reported" "$unknown_out" "no rule or rule set named 'nonesuch'"
+
+list_out=$(python3 "$MUTE" --watches "$RULES_DIR" --session "$SESS" list)
+check "list shows the muted set" "$list_out" "git"
+rm_out=$(python3 "$MUTE" --watches "$RULES_DIR" --session "$SESS" remove git)
+check "remove confirms the unmute" "$rm_out" "Unmuted git"
+run_test "$GIT" "after unmute, git commit asks again" ask "$(inp 'git commit -m x')"
+
+echo "=== CLI rejects an unsafe session id (no path escape) ==="
+canary="$CLAUDEWATCH_HOME/canary.json"
+rm -f "$canary"
+evil_out=$(python3 "$MUTE" --watches "$RULES_DIR" --session "../canary" add git 2>&1)
+check "unsafe --session is reported" "$evil_out" "unsafe ClaudeWatch session id"
+check "unsafe --session writes no mute file outside the store" "$([ -f "$canary" ] && echo escaped || echo contained)" "contained"
+
+echo "=== SessionEnd clears the session's mutes ([HK-05]) ==="
+python3 "$MUTE" --watches "$RULES_DIR" --session "$SESS" add git >/dev/null
+printf '{"session_id":"%s"}' "$SESS" | python3 "$MUTE" session-end
+check "session-end deleted the mute file" "$([ -f "$MUTES/$SESS.json" ] && echo present || echo gone)" "gone"
+
+print_results

--- a/tests/test-output.sh
+++ b/tests/test-output.sh
@@ -87,13 +87,18 @@ echo "--- multiple matched rules: each reason links independently, newline-joine
 assert_reason "multi: first rule linked"   "-u CLAUDEWATCH_HYPERLINKS" "$MULTI" "${OSC8}https://example.com/one${ST}first reason"  yes
 assert_reason "multi: second rule linked"  "-u CLAUDEWATCH_HYPERLINKS" "$MULTI" "${OSC8}https://example.com/two${ST}second reason" yes
 # Two violations → two lines (one newline). A regression that wrapped the joined
-# string in a single hyperlink, or dropped the newline, would fail here.
+# string in a single hyperlink, or dropped the newline, would fail the pre-blank
+# count. The [MUTE-08] mute hint follows a blank line; assert the post-blank
+# region is exactly one line too, so extra trailing output (a duplicated hint, a
+# stray appended line) is caught — the guarantee the whole-reason count once gave.
 TOTAL=$((TOTAL + 1))
-multi_lines=$(printf '%s\n' "$(fmt_reason "-u CLAUDEWATCH_HYPERLINKS" "$MULTI")" | wc -l | tr -d ' ')
-if [ "$multi_lines" = "2" ]; then
-  PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC}: multi: reasons are newline-joined (2 lines)"
+multi_reason=$(fmt_reason "-u CLAUDEWATCH_HYPERLINKS" "$MULTI")
+multi_pre=$(printf '%s\n' "$multi_reason" | awk '/^$/{exit} {print}' | wc -l | tr -d ' ')
+multi_post=$(printf '%s\n' "$multi_reason" | awk 'f{print} /^$/{f=1}' | wc -l | tr -d ' ')
+if [ "$multi_pre" = "2" ] && [ "$multi_post" = "1" ]; then
+  PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC}: multi: 2 reason lines + 1 mute-hint line, no extra output"
 else
-  FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC}: multi: reasons are newline-joined (got $multi_lines lines)"
+  FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC}: multi: expected 2 reason + 1 hint line (got pre=$multi_pre post=$multi_post)"
 fi
 
 echo "--- deny path uses the plain — url form (host strips OSC 8 on errors) ---"

--- a/tests/test-watchdog.sh
+++ b/tests/test-watchdog.sh
@@ -12,7 +12,7 @@ echo "========================================"
 echo "  claude-watchdog tests"
 echo "========================================"
 
-for test_file in "$SCRIPT_DIR"/test-watch-*.sh "$SCRIPT_DIR"/test-engine.sh "$SCRIPT_DIR"/test-output.sh "$SCRIPT_DIR"/test-logging.sh "$SCRIPT_DIR"/test-analyze.sh "$SCRIPT_DIR"/test-reset-decisions.sh "$SCRIPT_DIR"/test-ambient.sh; do
+for test_file in "$SCRIPT_DIR"/test-watch-*.sh "$SCRIPT_DIR"/test-engine.sh "$SCRIPT_DIR"/test-output.sh "$SCRIPT_DIR"/test-logging.sh "$SCRIPT_DIR"/test-analyze.sh "$SCRIPT_DIR"/test-reset-decisions.sh "$SCRIPT_DIR"/test-ambient.sh "$SCRIPT_DIR"/test-mutes.sh; do
   echo ""
   if bash "$test_file"; then
     :


### PR DESCRIPTION
## Context

ClaudeWatch's `PreToolUse` hook coalesces every rule match into `block` (unrecoverable, un-bypassable) or `ask` (recoverable, prompts each time). For a commit-heavy recipe, `watch-git`'s `ask` rules on `git commit` / `git commit --amend` fire on every single invocation — there's no way to say "stop asking me about this for the rest of the session," because the hook's decision schema is strictly per-invocation (`allow`/`deny`/`ask`, no "allow for this session"). The [spec commit](https://github.com/chris-peterson/ClaudeWatch/commit/b827eaf) specced the fix (§8, `MUTE-01..08`); this implements it.

A **session mute** silences a rule set's or an individual rule's `ask` prompts for the rest of the current session. `block` rules never consult it — muting `git` quiets `commit`/`amend`/`stash`, but `push --force` still fires — so it's safe to let the agent run and review the accumulated work at the end.

Rebased onto current `main`, which adopted [shipyard](https://github.com/chris-peterson/shipyard) since this branch was cut. The `SessionEnd` wiring accordingly moved into `hooks/hooks.yml` (the source of record) — shipyard generates `hooks.json`/`plugin.json` from it — rather than the hand-edited `hooks.json` the branch first used.

## Review guide

**Critical path**
- [`scripts/watchdog.py:42`](https://github.com/chris-peterson/ClaudeWatch/pull/18/files#diff-1534602ba772e4d20b71b0ec537f6f78c2ae4973cc5580cfec582ae46c384ec9R42) — the mute store: a pure file read keyed by the hook's `session_id`, no clock/network, so the decision stays deterministic
- [`scripts/watchdog.py:66`](https://github.com/chris-peterson/ClaudeWatch/pull/18/files#diff-1534602ba772e4d20b71b0ec537f6f78c2ae4973cc5580cfec582ae46c384ec9R66) — `session_id` is validated (`[A-Za-z0-9_-]`) before it becomes a mute-file path, so a stray separator or `..` can't escape the store. The single chokepoint both the read and the CLI write go through; on the decision path an invalid id degrades to "no mutes" (silence = allow)
- [`scripts/watchdog.py:563`](https://github.com/chris-peterson/ClaudeWatch/pull/18/files#diff-1534602ba772e4d20b71b0ec537f6f78c2ae4973cc5580cfec582ae46c384ec9R563) — the ask-loop skip: only reached after a rule already matched and cleared existing `except`/`unless_*` exemptions, and it never touches the `block` loop above it
- [`scripts/watchdog.py:851`](https://github.com/chris-peterson/ClaudeWatch/pull/18/files#diff-1534602ba772e4d20b71b0ec537f6f78c2ae4973cc5580cfec582ae46c384ec9R851) — the friction-point hint appended to the `ask` reason, after logging, so it never reaches the decision log

**Integration points**
- [`scripts/mute.py`](https://github.com/chris-peterson/ClaudeWatch/pull/18/files#diff-cddb54cc4ec56cd8af025783c5ba981ce00c6f36113d8f03227c735b4e05aeb4) — the write/read CLI (`add`/`remove`/`list`) plus the `session-end` hook subcommand; [`resolve()`](https://github.com/chris-peterson/ClaudeWatch/pull/18/files#diff-cddb54cc4ec56cd8af025783c5ba981ce00c6f36113d8f03227c735b4e05aeb4R83) is where a token maps to a rule set or rule. It takes the active session via `--session`, which the skill fills from `${CLAUDE_SESSION_ID}` — the same id the engine keys its read on, so a mute lands on exactly the session that asked for it
- [`hooks/hooks.yml:17`](https://github.com/chris-peterson/ClaudeWatch/pull/18/files#diff-aa8391c7f23302816c2ae045ffd9bc1cdfefdaf78458e751fe3a99800645ff87R17) — the `SessionEnd` hook (source of record; `hooks.json` is generated) clears a session's mutes on exit, so a mute never outlives its session

**Ancillary**
- `skills/mute/`, `skills/unmute/`, `skills/mutes/` — thin, model-invocable wrappers over the CLI, so natural language ("stop asking me about commits this session") routes in. Each passes `${CLAUDE_SESSION_ID}` through to the CLI
- [`tests/test-mutes.sh`](https://github.com/chris-peterson/ClaudeWatch/pull/18/files#diff-2eb55cf4e708da37218ae6d2f9afff9bad572a158cde549262e55a9aa73a1358) — engine suppression, block-still-fires, the hint, the CLI, session lifecycle, and the unsafe-`session_id` guard
- `SPEC.md`, `STATUS.md`, `README.md`, `plugin.yml` — spec reconciliation and coverage recount

## Approach & trade-offs

Individual rules are muted by their **name** (`git commit`) rather than a positional id. The spec originally proposed `<short>-ask-NN`-style stable ids (mirroring `/ClaudeWatch:rules`), but that's neither stable (reordering ask rules repoints it) nor discoverable (you'd have to open the rules editor and count). The rule name is the label the `ask` prompt already shows, so it's both.

The skill bridges its `session_id` to the CLI through Claude Code's `${CLAUDE_SESSION_ID}` skill-content substitution. That's the same id the engine reads on stdin, so write and read address the same session by construction — no `cwd`-keyed indirection, so two sessions in one directory can't cross-mute, and a mute can't land on a session that has already ended. `[HK-06]` (a `SessionStart` hook that had recorded a `cwd → session_id` pointer) is superseded and drops out of the coverage count.

## Testing

`just test` passes locally, including 22 assertions in `test-mutes.sh` (engine suppression, block-still-fires, the ask hint, the full CLI round-trip, the SessionEnd lifecycle, and the unsafe-`session_id` guard). This repo's CI runs the suite only at release time, not per-PR, so there's no automated signal on this PR itself. Beyond the suite, the CLI→engine round-trip was exercised by hand: a mute written for one `session_id` is honored only when the engine reads that same id, and a different session still gets the `ask`. What the harness can't drive is the `${CLAUDE_SESSION_ID}` substitution itself — it resolves only inside a live skill invocation — so the interactive `/ClaudeWatch:mute` path holds by construction (the CLI acts on whatever `--session` value the skill passes), not by an end-to-end run.
