### PR TITLE
Add opt-in is_recoverable predicate for unless_condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## Unreleased
+
+- **New `is_recoverable` predicate for `unless_condition`** (`scripts/watchdog.py`),
+  available for any rule set to reference. `is_relative_to_cwd` only checks
+  that a deletion target is spatially under `cwd`, on the *assumption* that
+  makes it recoverable from git history — that assumption is never actually
+  verified, so a bare, non-version-controlled working directory (e.g. a
+  workspace root whose children are individually git repos, but the root
+  itself isn't) gets silently exempted anyway. `is_recoverable` requires the
+  target to be under `cwd` **and** to actually be inside a real git work tree
+  or tracked by chezmoi, closing that gap. This is additive: no shipped rule
+  in `watches/` is changed to use it — `is_relative_to_cwd` remains the
+  default for `rm -rf`/`rm -r` in `watch-files.yml`, unchanged. Adopting
+  `is_recoverable` for a specific rule set (shipped or local) is left to the
+  maintainer's judgment, or to a user's own local rule override once
+  something like the durable user-rules-directory in FUT-04 exists.
+  Requires two new filesystem/subprocess calls (`git rev-parse
+  --is-inside-work-tree`, `chezmoi managed`) that `is_relative_to_cwd`
+  deliberately avoided to stay pure-string/deterministic (SPEC.md RL-16) —
+  an accepted tradeoff specific to this opt-in predicate, not a change to the
+  determinism contract for anything shipped. Covered by
+  `tests/test-predicate-is-recoverable.sh` against a demo-only fixture rule
+  set (`tests/fixtures/watch-is-recoverable-demo.yml`); `is_relative_to_cwd`'s
+  own existing test coverage in `tests/test-watch-files.sh` is untouched.
+
 ## 0.17.2
 
 Plugin metadata and skill-hygiene fixes from a plugin-dev best-practices scan.

--- a/scripts/watchdog.py
+++ b/scripts/watchdog.py
@@ -33,6 +33,7 @@ import json
 import os
 import re
 import shlex
+import subprocess
 import sys
 
 
@@ -310,40 +311,37 @@ def _is_compound_command(command):
 _UNRESOLVABLE_TARGET = re.compile(r"[~$`*?\[]|(?:^|/)\.\.(?:/|$)")
 
 
-def _targets_under_cwd(command, cwd):
-    """Whether every deletion target of an `rm` command resolves strictly under `cwd`.
-
-    Pure string analysis (no filesystem access) so the decision stays
-    deterministic. Backs the `is_relative_to_cwd` unless-condition: an in-tree
-    `rm -r` is recoverable from git history, so it need not prompt, while a
-    delete that reaches outside the working directory still does.
-
-    Returns False — decline the exemption, keep the ask — whenever in-tree-ness
-    can't be proven from the text: no cwd, a compound command, a parse failure,
-    a non-`rm` program, no targets, a target that is the working directory
-    itself or a `.git` directory, or any target carrying an unresolvable marker
-    (`~`, `$`, glob, `..`). Only an all-clear set of literal paths strictly
-    under cwd returns True. The working directory itself and any `.git`
-    directory are excluded because the git-history safety net the exemption
-    relies on does not cover wiping the whole tree or its history.
+def _rm_targets_under_cwd(command, cwd):
+    """Extract an `rm` command's deletion targets, resolved to absolute paths,
+    when every one of them can be proven (by pure string analysis, no
+    filesystem access) to resolve strictly under `cwd`. Returns `None` —
+    decline, caller should treat as "not provable" — whenever in-tree-ness
+    can't be established from the text: no cwd, a compound command, a parse
+    failure, a non-`rm` program, no targets, a target that is the working
+    directory itself or a `.git` directory, or any target carrying an
+    unresolvable marker (`~`, `$`, glob, `..`). Shared by `_targets_under_cwd`
+    (the existing `is_relative_to_cwd` predicate, unchanged behavior below)
+    and `_targets_recoverable` (which adds an actual recoverability check on
+    top of this same extraction — see that function's docstring for why the
+    two are separate predicates rather than one).
     """
     if not cwd:
-        return False
+        return None
     # A compound command is handled by the ask->deny escalation ([OUT-08]); don't
     # let the exemption pre-empt that, and don't try to reason about which tokens
     # belong to which segment.
     if _is_compound_command(command):
-        return False
+        return None
     try:
         tokens = shlex.split(command)
     except ValueError:
-        return False
+        return None
     # Skip leading `VAR=value` assignments and `sudo` to reach the program.
     i = 0
     while i < len(tokens) and (re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", tokens[i]) or tokens[i] == "sudo"):
         i += 1
     if i >= len(tokens) or os.path.basename(tokens[i]) != "rm":
-        return False
+        return None
 
     targets = []
     after_ddash = False
@@ -355,26 +353,134 @@ def _targets_under_cwd(command, cwd):
             continue  # a flag, not a target
         targets.append(tok)
     if not targets:
-        return False
+        return None
 
     cwd_norm = os.path.normpath(cwd)
+    resolved_targets = []
     for tok in targets:
         if _UNRESOLVABLE_TARGET.search(tok):
-            return False
+            return None
         resolved = os.path.normpath(tok if os.path.isabs(tok) else os.path.join(cwd_norm, tok))
         if resolved == cwd_norm or not resolved.startswith(cwd_norm + os.sep):
-            return False
+            return None
         if ".git" in os.path.relpath(resolved, cwd_norm).split(os.sep):
+            return None
+        resolved_targets.append(resolved)
+    return resolved_targets
+
+
+def _targets_under_cwd(command, cwd):
+    """Whether every deletion target of an `rm` command resolves strictly under `cwd`.
+
+    Pure string analysis (no filesystem access) so the decision stays
+    deterministic. Backs the `is_relative_to_cwd` unless-condition: an in-tree
+    `rm -r` is *assumed* recoverable from git history, so it need not prompt,
+    while a delete that reaches outside the working directory still does.
+    This assumption is unchecked — see `_targets_recoverable` below for an
+    opt-in variant that actually verifies it rather than inferring it from
+    location alone. Behavior here is unchanged from the existing predicate;
+    only the target-extraction internals were factored out into
+    `_rm_targets_under_cwd` so both predicates share one parser.
+    """
+    return _rm_targets_under_cwd(command, cwd) is not None
+
+
+def _is_in_git_worktree(path):
+    """Whether `path`'s containing directory is inside a real git work tree.
+
+    Requires a filesystem/subprocess call (`git -C <dir> rev-parse
+    --is-inside-work-tree`) — unlike `_targets_under_cwd`, this cannot be pure
+    string analysis, because "is this actually a git repo" is not knowable
+    from the command text alone. Fails closed (returns False) on any error —
+    git not on PATH, timeout, non-repo — so a check that can't be completed
+    never silently grants the exemption.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", os.path.dirname(path) or ".", "rev-parse", "--is-inside-work-tree"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+        return result.returncode == 0 and result.stdout.strip() == "true"
+    except Exception:
+        return False
+
+
+def _is_chezmoi_managed(path):
+    """Whether `path` itself (not just some descendant) is tracked by chezmoi.
+
+    `chezmoi managed --path-style=absolute <path>` lists managed entries at or
+    under `path`; an exact line match against the resolved path (not merely
+    non-empty output) confirms the path itself is managed, rather than being
+    an untracked file that happens to sit under a directory with unrelated
+    managed content elsewhere. Fails closed (returns False) on any error —
+    chezmoi not installed, timeout, not a chezmoi-managed machine — same
+    reasoning as `_is_in_git_worktree`. Harmless on machines that don't use
+    chezmoi: the subprocess call fails, this returns False, and callers fall
+    through to whatever the other recoverability check decides.
+    """
+    try:
+        result = subprocess.run(
+            ["chezmoi", "managed", "--path-style=absolute", path],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+        if result.returncode != 0:
             return False
-    return True
+        return path in result.stdout.splitlines()
+    except Exception:
+        return False
+
+
+def _targets_recoverable(command, cwd):
+    """Whether every deletion target of an `rm` command is BOTH under `cwd`
+    AND actually recoverable — inside a real git work tree, or tracked by
+    chezmoi — rather than merely assumed recoverable by virtue of location.
+
+    This is deliberately a separate, opt-in predicate alongside
+    `is_relative_to_cwd` / `_targets_under_cwd`, not a replacement for it —
+    no shipped rule in `watches/` is changed to use this by default. "Under
+    cwd" is a *scope* gate (the agent had an obvious reason to be there —
+    mirrors auto mode's own "Local Operations" exception, which likewise
+    limits to project scope); this predicate additionally verifies the
+    *recoverability* assumption that gate's original rationale depends on,
+    instead of taking it on faith. The gap it closes: a bare, non-version-
+    controlled working directory (e.g. a VS Code workspace root whose
+    children are individually git repos, but the root itself isn't) gets
+    silently exempted by `is_relative_to_cwd` today on an assumption that
+    never holds there. A `/tmp`-style scratch directory (already exempted via
+    `unless_regex` in `watch-files.yml`) is intentionally NOT run through
+    this check — ephemeral scratch space isn't expected to be tracked by
+    anything, and requiring it to be would defeat that separate exemption's
+    purpose.
+
+    Involves real filesystem/subprocess calls (see `_is_in_git_worktree`,
+    `_is_chezmoi_managed`), unlike the pure-string `_targets_under_cwd` this
+    builds on — recoverability is a fact about the filesystem, not something
+    derivable from command text alone, so this predicate trades the original
+    predicate's pure-string determinism for two bounded (3s timeout each),
+    fail-closed subprocess calls per distinct target.
+    """
+    targets = _rm_targets_under_cwd(command, cwd)
+    if targets is None:
+        return False
+    return all(_is_in_git_worktree(t) or _is_chezmoi_managed(t) for t in targets)
 
 
 # Named predicates an `unless_condition` entry can reference. Each takes the bash
 # command and the hook's `cwd` and returns True when the rule's ask should be
 # skipped. Keep this the single registry of valid condition names — an unknown
 # name surfaces as a config-error deny rather than silently never matching.
+#
+# `is_recoverable` is available here for any rule set (shipped or local) to
+# opt into, but no shipped rule in `watches/` references it — `is_relative_to_cwd`
+# remains what ships by default. See `_targets_recoverable`'s docstring for
+# the gap this closes and why it's additive rather than a default swap.
 _PREDICATES = {
     "is_relative_to_cwd": _targets_under_cwd,
+    "is_recoverable": _targets_recoverable,
 }
 
 

--- a/tests/fixtures/watch-is-recoverable-demo.yml
+++ b/tests/fixtures/watch-is-recoverable-demo.yml
@@ -1,0 +1,7 @@
+rules:
+  ask:
+    - name: rm -r (is_recoverable demo)
+      pattern: 'rm\s+-[a-zA-Z]*r'
+      unless_condition: [is_recoverable]
+      reason: recursively deletes directories
+      ref: https://man7.org/linux/man-pages/man1/rm.1.html

--- a/tests/test-predicate-is-recoverable.sh
+++ b/tests/test-predicate-is-recoverable.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+source "$(cd "$(dirname "$0")" && pwd)/harness.sh"
+
+# Exercises the new `is_recoverable` predicate through the real rule engine,
+# against a demo-only fixture rule set (fixtures/watch-is-recoverable-demo.yml)
+# rather than any shipped rule in watches/ — no default rule references this
+# predicate, so this file is what actually proves the predicate behaves as
+# documented.
+RULES="$SCRIPT_DIR/fixtures/watch-is-recoverable-demo.yml"
+t() { run_test "$RULES" "$@"; }
+
+echo "=== is_recoverable predicate ==="
+
+# is_recoverable (unlike is_relative_to_cwd) checks the filesystem, so the
+# "should allow" cases below need a real git-initialized temp repo — a merely
+# symbolic cwd can't satisfy the recoverability check.
+REPO_DIR="$(mktemp -d)"
+UNTRACKED_DIR="$(mktemp -d)"
+trap 'rm -rf "$REPO_DIR" "$UNTRACKED_DIR"' EXIT
+git -C "$REPO_DIR" init -q
+# git -C <dir> requires <dir> to actually exist (it chdir's before checking
+# repo status) -- pre-create the subdirectory the test below targets.
+mkdir -p "$REPO_DIR/src"
+
+echo "--- in-tree AND git-tracked: allowed ---"
+t "rm -r in-tree relative"      allow "{\"tool_name\":\"Bash\",\"cwd\":\"$REPO_DIR\",\"tool_input\":{\"command\":\"rm -r old-dir\"}}"
+t "rm -r in-tree subdir"        allow "{\"tool_name\":\"Bash\",\"cwd\":\"$REPO_DIR\",\"tool_input\":{\"command\":\"rm -r src/legacy\"}}"
+t "rm -r in-tree absolute"      allow "{\"tool_name\":\"Bash\",\"cwd\":\"$REPO_DIR\",\"tool_input\":{\"command\":\"rm -r $REPO_DIR/build\"}}"
+
+echo "--- the actual gap this predicate closes: in-tree but NOT git/chezmoi-tracked still prompts ---"
+# A bare, non-version-controlled working directory (e.g. a VS Code workspace
+# root whose children are individually git repos, but the root itself isn't)
+# must NOT be silently exempted just because the target is spatially "under
+# cwd" -- is_relative_to_cwd alone would allow this; is_recoverable does not.
+t "rm -r in-tree but untracked" ask "{\"tool_name\":\"Bash\",\"cwd\":\"$UNTRACKED_DIR\",\"tool_input\":{\"command\":\"rm -r old-dir\"}}"
+
+echo "--- out-of-tree still prompts, same as is_relative_to_cwd ---"
+t "rm -r out-of-tree absolute"  ask "{\"tool_name\":\"Bash\",\"cwd\":\"$REPO_DIR\",\"tool_input\":{\"command\":\"rm -r /etc/foo\"}}"
+
+print_results

--- a/tests/test-watchdog.sh
+++ b/tests/test-watchdog.sh
@@ -12,7 +12,7 @@ echo "========================================"
 echo "  claude-watchdog tests"
 echo "========================================"
 
-for test_file in "$SCRIPT_DIR"/test-watch-*.sh "$SCRIPT_DIR"/test-engine.sh "$SCRIPT_DIR"/test-output.sh "$SCRIPT_DIR"/test-logging.sh "$SCRIPT_DIR"/test-analyze.sh "$SCRIPT_DIR"/test-reset-decisions.sh "$SCRIPT_DIR"/test-ambient.sh; do
+for test_file in "$SCRIPT_DIR"/test-watch-*.sh "$SCRIPT_DIR"/test-engine.sh "$SCRIPT_DIR"/test-output.sh "$SCRIPT_DIR"/test-logging.sh "$SCRIPT_DIR"/test-analyze.sh "$SCRIPT_DIR"/test-reset-decisions.sh "$SCRIPT_DIR"/test-ambient.sh "$SCRIPT_DIR"/test-predicate-is-recoverable.sh; do
   echo ""
   if bash "$test_file"; then
     :


### PR DESCRIPTION
*Beep boop, I am Claude Code 🤖, my user has reviewed and approved the following written by me:*

## What this adds

A new `is_recoverable` predicate for `unless_condition`, alongside the existing `is_relative_to_cwd`. Purely additive — no shipped rule in `watches/` is changed to use it. `is_relative_to_cwd` remains the default for `rm -rf`/`rm -r` in `watch-files.yml`, unchanged and fully covered by its existing tests.

## Why

`is_relative_to_cwd` checks that a delete target is spatially under `cwd`, on the assumption that makes it recoverable from git history — but that assumption is never actually verified. It doesn't hold for a bare, non-version-controlled working directory (e.g. a VS Code workspace root whose children are individually git repos, but the root itself isn't — a pattern that turns out to be common: an IDE workspace grouping several unrelated project checkouts under one un-tracked parent folder). In that case, `is_relative_to_cwd` silently exempts a recursive delete that has no git history to recover from at all.

`is_recoverable` closes that gap: it requires the target to be under `cwd` **and** to actually be inside a real git work tree or tracked by chezmoi (a dotfile manager some users run against `$HOME`), verified via `git rev-parse --is-inside-work-tree` and `chezmoi managed`. Both checks fail closed on any error (git/chezmoi not installed, timeout, non-repo) — a check that can't complete never grants the exemption.

This surfaced from real production use of this plugin (`--permission-mode auto` + ClaudeWatch, ~3 weeks of logged decisions on one machine) and a specific documented incident where the gap almost let an in-tree, non-recoverable delete through under an assumed-safe workspace layout.

## Scope discipline

I deliberately kept this narrow rather than porting a local patch wholesale:

- The predicate is **additive only** — registered in `_PREDICATES`, referenced by no shipped rule. Whether/when to wire it into any default rule is a maintainer call, not something I wanted to force via a drive-by PR.
- New tests live in their own file (`tests/test-predicate-is-recoverable.sh`) against a demo-only fixture rule set (`tests/fixtures/watch-is-recoverable-demo.yml`) — the existing `is_relative_to_cwd` coverage in `tests/test-watch-files.sh` is untouched, byte-for-byte.
- Full suite (`tests/test-watchdog.sh`) passes with this branch, including the new file wired into its dispatcher list (its name doesn't match the `test-watch-*.sh` glob, so it needed an explicit entry — same pattern as `test-engine.sh`/`test-output.sh`/etc.).
- `_targets_under_cwd` (backing `is_relative_to_cwd`) is behaviorally unchanged; its target-extraction logic was factored out into a shared `_rm_targets_under_cwd` helper so both predicates parse `rm` invocations the same way, rather than duplicating that logic.

## Tradeoff, stated plainly

`is_relative_to_cwd` is pure string analysis — no filesystem access, fully deterministic (per `SPEC.md` RL-16). `is_recoverable` requires real subprocess calls (`git`, `chezmoi`), each bounded to a 3s timeout and fail-closed. That's an accepted cost specific to this opt-in predicate, not a change to the determinism contract for anything shipped by default.

## What I didn't do

I didn't try to build a durable way for a user to opt this into their own rule set without forking `watches/` — I noticed `SPEC.md`'s `[FUT-04]` already scopes exactly that mechanism (a user rules directory that survives plugin upgrades) as a planned-but-unbuilt item, and building it wasn't this PR's job. This predicate is meant to be ready for that mechanism once it exists, or for a maintainer decision to wire it into a shipped rule directly — either is your call, not mine to make unilaterally.

Happy to adjust scope, naming, or test structure based on whatever's easiest to review.

*Beep boop, Claude Code 🤖 out!*
